### PR TITLE
[ Design ] 후배_약속날짜 선택 캘린더 퍼블리싱

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -39,22 +39,17 @@
           "flex-grow",
           "flex-shrink",
           "align-self",
-
           "visibility",
-
           "overflow",
           "overflow-x",
           "overflow-y",
-
           "float",
           "clear",
-
           "position",
           "top",
           "right",
           "bottom",
           "left",
-
           "z-index"
         ]
       },
@@ -66,23 +61,19 @@
           "width",
           "min-width",
           "max-width",
-
           "height",
           "min-height",
           "max-height",
-
           "margin",
           "margin-top",
           "margin-right",
           "margin-bottom",
           "margin-left",
-
           "padding",
           "padding-top",
           "padding-right",
           "padding-bottom",
           "padding-left",
-
           "border",
           "border-top",
           "border-right",
@@ -116,14 +107,11 @@
           "font-style",
           "font-size",
           "font-weight",
-
           "text-align",
           "vertical-align",
           "line-height",
-
           "text-transform",
           "text-decoration",
-
           "letter-spacing",
           "text-indent",
           "white-space"
@@ -135,6 +123,7 @@
         "noEmptyLineBetween": true,
         "properties": ["cursor", "opacity", "animation", "transition"]
       }
-    ]
+    ],
+    "selector-class-pattern": null
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,8 +18,10 @@
     "axios": "^1.7.2",
     "emotion-reset": "^3.0.1",
     "jwt-decode": "^4.0.0",
+    "moment": "^2.30.1",
     "prettier": "^3.3.2",
     "react": "^18.3.1",
+    "react-calendar": "^5.0.0",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.24.0"
   },

--- a/src/pages/juniorPromise/components/CustomCalendar.tsx
+++ b/src/pages/juniorPromise/components/CustomCalendar.tsx
@@ -3,12 +3,28 @@ import { useState } from 'react';
 import Calendar from 'react-calendar';
 import 'react-calendar/dist/Calendar.css';
 
+interface CalendarTileProperties {
+  date: Date;
+  view: string;
+}
+
 type ValuePiece = Date | null;
 
 type Value = ValuePiece | [ValuePiece, ValuePiece];
 
 const CustomCalendar = () => {
   const [value, onChange] = useState<Value>(new Date());
+
+  const tileDisabled = ({ date, view }: CalendarTileProperties) => {
+    return view === 'month' && date <= new Date();
+  };
+
+  const tileClassName = ({ date, view }: CalendarTileProperties) => {
+    if (view === 'month' && date <= new Date()) {
+      return 'disabled-date';
+    }
+    return '';
+  };
 
   return (
     <CalendarContainer>
@@ -22,6 +38,8 @@ const CustomCalendar = () => {
         calendarType={'iso8601'}
         defaultValue={[new Date(2024, 7, 1), new Date(2024, 7, 1)]}
         formatDay={(locale, date) => date.getDate().toString()}
+        tileDisabled={tileDisabled}
+        tileClassName={tileClassName}
       />
     </CalendarContainer>
   );
@@ -72,7 +90,6 @@ const StyledCalendar = styled(Calendar)`
 
   .react-calendar__month-view__weekdays {
     color: ${({ theme }) => theme.colors.grayScaleMG2};
-
     ${({ theme }) => theme.fonts.Title2_M_16};
   }
 
@@ -109,5 +126,11 @@ const StyledCalendar = styled(Calendar)`
 
   .react-calendar__month-view__weekdays abbr {
     text-decoration: none;
+  }
+
+  .disabled-date {
+    color: ${({ theme }) => theme.colors.grayScaleLG2} !important;
+
+    cursor: not-allowed;
   }
 `;

--- a/src/pages/juniorPromise/components/CustomCalendar.tsx
+++ b/src/pages/juniorPromise/components/CustomCalendar.tsx
@@ -1,0 +1,113 @@
+import styled from '@emotion/styled';
+import { useState } from 'react';
+import Calendar from 'react-calendar';
+import 'react-calendar/dist/Calendar.css';
+
+type ValuePiece = Date | null;
+
+type Value = ValuePiece | [ValuePiece, ValuePiece];
+
+const CustomCalendar = () => {
+  const [value, onChange] = useState<Value>(new Date());
+
+  return (
+    <CalendarContainer>
+      <StyledCalendar
+        onChange={onChange}
+        value={value}
+        minDate={new Date()}
+        next2Label={null}
+        prev2Label={null}
+        showNeighboringMonth={false}
+        calendarType={'iso8601'}
+        defaultValue={[new Date(2024, 7, 1), new Date(2024, 7, 1)]}
+        formatDay={(locale, date) => date.getDate().toString()}
+      />
+    </CalendarContainer>
+  );
+};
+
+export default CustomCalendar;
+
+const CalendarContainer = styled.div`
+  max-width: 100%;
+  padding: 20px;
+
+  background: ${({ theme }) => theme.colors.grayScaleWhite};
+`;
+
+const StyledCalendar = styled(Calendar)`
+  width: 100%;
+  padding-bottom: 3rem;
+  border: none;
+  border-radius: 8px;
+
+  background: ${({ theme }) => theme.colors.grayScaleWhite};
+
+  .react-calendar__navigation {
+    display: flex;
+    justify-content: space-around;
+    align-items: center;
+
+    padding: 0 7rem;
+  }
+
+  .react-calendar__tile {
+    max-width: 100%;
+    ${({ theme }) => theme.fonts.Title2_M_16};
+    border-radius: 100px;
+
+    background: none;
+
+    text-align: center;
+
+    cursor: pointer;
+  }
+
+  .react-calendar__tile--active {
+    border-radius: 100px;
+
+    background-color: ${({ theme }) => theme.colors.Blue};
+  }
+
+  .react-calendar__month-view__weekdays {
+    color: ${({ theme }) => theme.colors.grayScaleMG2};
+
+    ${({ theme }) => theme.fonts.Title2_M_16};
+  }
+
+  .react-calendar__tile:enabled:focus {
+    ${({ theme }) => theme.fonts.Title2_M_16};
+    background: ${({ theme }) => theme.colors.Blue};
+  }
+
+  .react-calendar__navigation button {
+    ${({ theme }) => theme.fonts.Head2_SB_18};
+  }
+
+  .react-calendar__navigation button:disabled {
+    background: none;
+  }
+
+  .react-calendar__navigation button:hover,
+  .react-calendar__navigation button:focus {
+    background: none;
+    background-color: transparent;
+
+    color: ${({ theme }) => theme.colors.grayScaleDG};
+  }
+
+  .react-calendar__navigation__prev-button,
+  .react-calendar__navigation__next-button {
+    border-radius: 100px;
+  }
+
+  .react-calendar__month-view__days__day--weekend {
+    ${({ theme }) => theme.fonts.Title2_M_16};
+    color: ${({ theme }) => theme.colors.grayScaleBG};
+  }
+
+  .react-calendar__month-view__weekdays abbr {
+    text-decoration: none;
+  }
+`;

--- a/src/pages/juniorPromise/components/CustomCalendar.tsx
+++ b/src/pages/juniorPromise/components/CustomCalendar.tsx
@@ -21,12 +21,8 @@ const CustomCalendar = () => {
     return view === 'month' && date <= new Date();
   };
 
-  const tileClassName = ({ date, view }: CalendarTileProperties) => {
-    if (view === 'month' && date <= new Date()) {
-      return 'disabled-date';
-    }
-    return '';
-  };
+  const tileClassName = ({ date, view }: CalendarTileProperties) =>
+    view === 'month' && date <= new Date() ? 'disabled-date' : '';
 
   return (
     <CalendarContainer>

--- a/src/pages/juniorPromise/components/CustomCalendar.tsx
+++ b/src/pages/juniorPromise/components/CustomCalendar.tsx
@@ -34,7 +34,6 @@ const CustomCalendar = () => {
         prev2Label={null}
         showNeighboringMonth={false}
         calendarType={'iso8601'}
-        defaultValue={[new Date(2024, 7, 1), new Date(2024, 7, 1)]}
         formatDay={(locale, date) => date.getDate().toString()}
         tileDisabled={tileDisabled}
         tileClassName={tileClassName}

--- a/src/pages/juniorPromise/components/CustomCalendar.tsx
+++ b/src/pages/juniorPromise/components/CustomCalendar.tsx
@@ -113,6 +113,8 @@ const StyledCalendar = styled(Calendar)`
 
   .react-calendar__navigation button:disabled {
     background: none;
+
+    color: ${({ theme }) => theme.colors.grayScaleDG};
   }
 
   .react-calendar__navigation button:hover,

--- a/src/pages/juniorPromise/components/CustomCalendar.tsx
+++ b/src/pages/juniorPromise/components/CustomCalendar.tsx
@@ -70,6 +70,7 @@ const StyledCalendar = styled(Calendar)`
   .react-calendar__tile {
     max-width: 100%;
     ${({ theme }) => theme.fonts.Title2_M_16};
+    padding: 1.1rem 0;
     border-radius: 100px;
 
     background: none;

--- a/src/pages/juniorPromise/components/CustomCalendar.tsx
+++ b/src/pages/juniorPromise/components/CustomCalendar.tsx
@@ -109,6 +109,7 @@ const StyledCalendar = styled(Calendar)`
 
   .react-calendar__navigation button {
     ${({ theme }) => theme.fonts.Head2_SB_18};
+    min-width: 4rem;
   }
 
   .react-calendar__navigation button:disabled {

--- a/src/pages/juniorPromise/components/CustomCalendar.tsx
+++ b/src/pages/juniorPromise/components/CustomCalendar.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 import { useState } from 'react';
 import Calendar from 'react-calendar';
 import 'react-calendar/dist/Calendar.css';
+import { getTomorrow } from '../utils/getTomorrow';
 
 interface CalendarTileProperties {
   date: Date;
@@ -11,14 +12,6 @@ interface CalendarTileProperties {
 type ValuePiece = Date | null;
 
 type Value = ValuePiece | [ValuePiece, ValuePiece];
-
-// 내일 날짜를 구하는 함수
-const getTomorrow = () => {
-  const today = new Date();
-  const tomorrow = new Date(today);
-  tomorrow.setDate(today.getDate() + 1);
-  return tomorrow;
-};
 
 const CustomCalendar = () => {
   // 초기값을 내일 날짜로 설정

--- a/src/pages/juniorPromise/components/CustomCalendar.tsx
+++ b/src/pages/juniorPromise/components/CustomCalendar.tsx
@@ -84,6 +84,8 @@ const StyledCalendar = styled(Calendar)`
     border-radius: 100px;
 
     background-color: ${({ theme }) => theme.colors.Blue};
+
+    color: ${({ theme }) => theme.colors.grayScaleWhite};
   }
 
   .react-calendar__month-view__weekdays {
@@ -107,6 +109,13 @@ const StyledCalendar = styled(Calendar)`
     background: none;
 
     color: ${({ theme }) => theme.colors.grayScaleDG};
+  }
+
+  .react-calendar__tile--active:enabled:hover,
+  .react-calendar__tile--active:enabled:focus {
+    background: ${({ theme }) => theme.colors.Blue};
+
+    color: ${({ theme }) => theme.colors.grayScaleWhite};
   }
 
   .react-calendar__navigation button:hover,

--- a/src/pages/juniorPromise/components/CustomCalendar.tsx
+++ b/src/pages/juniorPromise/components/CustomCalendar.tsx
@@ -12,8 +12,17 @@ type ValuePiece = Date | null;
 
 type Value = ValuePiece | [ValuePiece, ValuePiece];
 
+// 내일 날짜를 구하는 함수
+const getTomorrow = () => {
+  const today = new Date();
+  const tomorrow = new Date(today);
+  tomorrow.setDate(today.getDate() + 1);
+  return tomorrow;
+};
+
 const CustomCalendar = () => {
-  const [value, onChange] = useState<Value>(new Date());
+  // 초기값을 내일 날짜로 설정
+  const [value, onChange] = useState<Value>(getTomorrow());
 
   const tileDisabled = ({ date, view }: CalendarTileProperties) => {
     return view === 'month' && date <= new Date();

--- a/src/pages/juniorPromise/components/CustomCalendar.tsx
+++ b/src/pages/juniorPromise/components/CustomCalendar.tsx
@@ -47,7 +47,7 @@ export default CustomCalendar;
 
 const CalendarContainer = styled.div`
   max-width: 100%;
-  padding: 20px;
+  padding: 2rem;
 
   background: ${({ theme }) => theme.colors.grayScaleWhite};
 `;
@@ -94,6 +94,8 @@ const StyledCalendar = styled(Calendar)`
   .react-calendar__tile:enabled:focus {
     ${({ theme }) => theme.fonts.Title2_M_16};
     background: ${({ theme }) => theme.colors.Blue};
+
+    color: ${({ theme }) => theme.colors.grayScaleWhite};
   }
 
   .react-calendar__navigation button {

--- a/src/pages/juniorPromise/utils/getTomorrow.ts
+++ b/src/pages/juniorPromise/utils/getTomorrow.ts
@@ -1,0 +1,7 @@
+// 내일 날짜를 구하는 함수
+export const getTomorrow = () => {
+  const today = new Date();
+  const tomorrow = new Date(today);
+  tomorrow.setDate(today.getDate() + 1);
+  return tomorrow;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -941,6 +941,11 @@
     "@types/babel__core" "^7.20.5"
     react-refresh "^0.14.2"
 
+"@wojtekmaj/date-utils@^1.1.3":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@wojtekmaj/date-utils/-/date-utils-1.5.1.tgz#c3cd67177ac781cfa5736219d702a55a2aea5f2b"
+  integrity sha512-+i7+JmNiE/3c9FKxzWFi2IjRJ+KzZl1QPu6QNrsgaa2MuBgXvUy4gA1TVzf/JMdIIloB76xSKikTWuyYAIVLww==
+
 acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
@@ -1247,6 +1252,11 @@ chalk@^4.0.0:
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
+
+clsx@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
+  integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
 
 color-convert@^1.9.0:
   version "1.9.3"
@@ -2084,6 +2094,13 @@ get-symbol-description@^1.0.2:
     es-errors "^1.3.0"
     get-intrinsic "^1.2.4"
 
+get-user-locale@^2.2.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/get-user-locale/-/get-user-locale-2.3.2.tgz#d37ae6e670c2b57d23a96fb4d91e04b2059d52cf"
+  integrity sha512-O2GWvQkhnbDoWFUJfaBlDIKUEdND8ATpBXD6KXcbhxlfktyD/d8w6mkzM/IlQEqGZAMz/PW6j6Hv53BiigKLUQ==
+  dependencies:
+    mem "^8.0.0"
+
 glob-parent@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
@@ -2625,7 +2642,7 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==
 
-loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -2646,6 +2663,13 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
+map-age-cleaner@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz#7d583a7306434c055fe474b0f45078e6e1b4b92a"
+  integrity sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==
+  dependencies:
+    p-defer "^1.0.0"
+
 mathml-tag-names@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz#4ddadd67308e780cf16a47685878ee27b736a0a3"
@@ -2655,6 +2679,14 @@ mdn-data@2.0.30:
   version "2.0.30"
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.30.tgz#ce4df6f80af6cfbe218ecd5c552ba13c4dfa08cc"
   integrity sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==
+
+mem@^8.0.0:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/mem/-/mem-8.1.1.tgz#cf118b357c65ab7b7e0817bdf00c8062297c0122"
+  integrity sha512-qFCFUDs7U3b8mBDPyz5EToEKoAkgCzqquIgi9nkkR9bixxOVOre+09lbuH7+9Kn2NFpm56M3GUWVbU2hQgdACA==
+  dependencies:
+    map-age-cleaner "^0.1.3"
+    mimic-fn "^3.1.0"
 
 meow@^13.2.0:
   version "13.2.0"
@@ -2686,6 +2718,11 @@ mime-types@^2.1.12:
   dependencies:
     mime-db "1.52.0"
 
+mimic-fn@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-3.1.0.tgz#65755145bbf3e36954b949c16450427451d5ca74"
+  integrity sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==
+
 minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
@@ -2704,6 +2741,11 @@ minimist@^1.2.0, minimist@^1.2.6:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
+
+moment@^2.30.1:
+  version "2.30.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.30.1.tgz#f8c91c07b7a786e30c59926df530b4eac96974ae"
+  integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==
 
 ms@2.1.2:
   version "2.1.2"
@@ -2840,6 +2882,11 @@ optionator@^0.9.3:
     prelude-ls "^1.2.1"
     type-check "^0.4.0"
     word-wrap "^1.2.5"
+
+p-defer@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-1.0.0.tgz#9f6eb182f6c9aa8cd743004a7d4f96b196b0fb0c"
+  integrity sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==
 
 p-limit@^3.0.2:
   version "3.1.0"
@@ -3005,6 +3052,16 @@ queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
+
+react-calendar@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/react-calendar/-/react-calendar-5.0.0.tgz#cf302db689ee1bba53d92644f7543e12164a7c0e"
+  integrity sha512-bHcE5e5f+VUKLd4R19BGkcSQLpuwjKBVG0fKz74cwPW5xDfNsReHdDbfd4z3mdjuUuZzVtw4Q920mkwK5/ZOEg==
+  dependencies:
+    "@wojtekmaj/date-utils" "^1.1.3"
+    clsx "^2.0.0"
+    get-user-locale "^2.2.1"
+    warning "^4.0.0"
 
 react-dom@^18.3.1:
   version "18.3.1"
@@ -3666,6 +3723,13 @@ vite@^5.3.1:
     rollup "^4.13.0"
   optionalDependencies:
     fsevents "~2.3.3"
+
+warning@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
+  integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
+  dependencies:
+    loose-envify "^1.0.0"
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #63

## ✅ Done Task
  - [x] 약속 날짜 선택 캘린더 퍼블리싱 (react-calendar 라이브러리 커스텀) 

## ☀️ New-insight
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) --> 
https://www.npmjs.com/package/react-calendar
### ☁️ react-calendar 라이브러리 커스텀 방법
📍 onChange는 날짜가 변경되었을 때 호출되는 함수입니다. 사용자가 달력에서 날짜를 선택할 때마다 이 함수가 호출되어 선택된 날짜가 value로 전달됩니다.
📍 value는 현재 선택된 날짜 또는 날짜 범위입니다. 단일 날짜 또는 날짜 배열을 지원하며, 캘린더가 이 값에 따라 초기 선택 상태를 표시합니다.
📍 minDate는 선택할 수 있는 최소 날짜를 지정합니다. 
📍 calendarType은 달력의 유형을 설정합니다. 주가 월요일부터 시작합니다.

```
 <StyledCalendar
        onChange={onChange}
        value={value}
        minDate={new Date()}
        next2Label={null}
        prev2Label={null}
        showNeighboringMonth={false}
        calendarType={'iso8601'}
        defaultValue={[new Date(2024, 7, 1), new Date(2024, 7, 1)]}
        formatDay={(locale, date) => date.getDate().toString()}
        tileDisabled={tileDisabled}
        tileClassName={tileClassName}
      />
```

### ☁️ react-calendar 라이브러리 UI 퍼블리싱
규칙 :`.react-calendar__` 접두사에 뒤의 명령어 붙이기. 개발자 도구로 확인하면서 구현할 수 있었습니다!
ex)
 - `.react-calendar__navigation`: 캘린더 내비게이션 바 스타일링.
 - `.react-calendar__tile`: 날짜 타일의 기본 스타일링.
 - `.react-calendar__tile--active`: 활성 날짜 타일의 스타일링.
 - `.react-calendar__tile--now`: 오늘 날짜 타일의 스타일링.
 - `.react-calendar__month-view__days__day--weekend`: 주말 날짜 타일의 스타일링.
 - `.react-calendar__month-view__weekdays`: 요일 이름의 스타일링.
 - `.react-calendar__tile:enabled:hover`, `.react-calendar__tile:enabled:focus`: 활성화된 날짜 타일의 호버 및 포커스 스타일링.
 - `.react-calendar__navigation button`: 내비게이션 버튼의 스타일링.
 - `.react-calendar__navigation button:hover`, `.react-calendar__navigation button:focus`: 내비게이션 버튼의 호버 및 포커스 스타일링.
 - `.react-calendar__navigation__prev-button`, `.react-calendar__navigation__next-button`: 이전 및 다음 버튼의 스타일링.
 - `.react-calendar__month-view__weekdays abbr`: 요일 약어의 스타일링.

react-calendar 컴포넌트에 커스텀 스타일을 적용하여 원하는 UI 를 만들었습니다!



## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->
### 🍀 내일 날짜부터 선택 가능해야 함
new Date()를 사용해서 오늘 날짜의 +1이 되는 내일 날짜를 구하는 함수를 작성하고, 반환합니다.
```
// 내일 날짜를 구하는 함수
const getTomorrow = () => {
  const today = new Date();
  const tomorrow = new Date(today);
  tomorrow.setDate(today.getDate() + 1);
  return tomorrow;
};
```
내일 날짜를 useState의 기본값으로 두어서, 렌더링 초기값을 내일 날짜로 설정합니다. 
date가 오늘 날짜(new Date())보다 작거나 같은 경우, 해당 날짜를 비활성화합니다. 이는 오늘 이전의 모든 날짜를 선택할 수 없도록 설정합니다.

### 🍀 비활성화된 날짜에 대해 특정 스타일을 적용
리액트-캘린더 라이브러리 커스텀특성 상 '주말' 숫자에 빨간색 색상이 입혀지거나/ 빨간색을 검은색으로 덮기 위해 속성을 적용하면 오늘 날짜 이전 주말 날짜에 '검은색'이 덮여지는 이슈가 있습니다!
따라서 오늘의 이전 날짜는 회색으로 설정하기 위해선 별도의 로직이 필요했습니다!
이와 같은 로직으로 클릭 불가한 부분은 회색으로 설정하고, 클릭이 안되도록 구현했습니다.
```
const tileClassName = ({ date, view }: CalendarTileProperties) => {
  if (view === 'month' && date <= new Date()) {
    return 'disabled-date';
  }
  return '';
};
```
```
.disabled-date {
  color: gray;
  cursor: not-allowed;
}
```

```
// 초기값을 내일 날짜로 설정
  const [value, onChange] = useState<Value>(getTomorrow());

  const tileDisabled = ({ date, view }: CalendarTileProperties) => {
    return view === 'month' && date <= new Date();
  };

  const tileClassName = ({ date, view }: CalendarTileProperties) => {
    if (view === 'month' && date <= new Date()) {
      return 'disabled-date';
    }
    return '';
  };
```

## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->

![image](https://github.com/TEAM-SEONYAK/SEONYAK_CLIENT/assets/99737532/1bffa580-e016-4c98-bf74-3f01ec31ff60)

https://github.com/TEAM-SEONYAK/SEONYAK_CLIENT/assets/99737532/c863ddfa-3345-4114-9c27-b54c66d42c50

