### PR TITLE
[ Feat ] CTA 관련 조건부 렌더링 

### DIFF
--- a/src/components/commons/FullButton.tsx
+++ b/src/components/commons/FullButton.tsx
@@ -23,7 +23,7 @@ const Wrapper = styled.div`
   right: 0;
   bottom: 0;
   left: 0;
-  z-index: 2;
+  z-index: 9;
 
   width: 100%;
   padding: 3.6rem 2rem;

--- a/src/components/commons/FullButton.tsx
+++ b/src/components/commons/FullButton.tsx
@@ -3,12 +3,12 @@ import styled from '@emotion/styled';
 // 화면 하단 풀사이즈 버튼
 interface FullBtnPropType {
   isActive?: boolean;
-  text: string;
+  text?: string;
   onClick?: () => void;
 }
 
 export const FullBtn = (props: FullBtnPropType) => {
-  const { isActive, text, onClick } = props;
+  const { isActive, text = '다음으로', onClick } = props;
   return (
     <Wrapper>
       <FullBtnWrapper type="button" disabled={!isActive} onClick={onClick}>

--- a/src/components/commons/FullButton.tsx
+++ b/src/components/commons/FullButton.tsx
@@ -10,23 +10,29 @@ interface FullBtnPropType {
 export const FullBtn = (props: FullBtnPropType) => {
   const { isActive, text, onClick } = props;
   return (
-    <FullBtnWrapper type="button" disabled={!isActive} onClick={onClick}>
-      {text}
-    </FullBtnWrapper>
+    <Wrapper>
+      <FullBtnWrapper type="button" disabled={!isActive} onClick={onClick}>
+        {text}
+      </FullBtnWrapper>
+    </Wrapper>
   );
 };
 
+const Wrapper = styled.div`
+  position: fixed;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 2;
+
+  width: 100%;
+  padding: 3.6rem 2rem;
+`;
 const FullBtnWrapper = styled.button`
   display: flex;
   justify-content: center;
   align-items: center;
-  position: fixed;
-  bottom: 3.8rem;
-  left: 50%;
-  z-index: 2;
-  transform: translateX(-50%);
 
-  height: 4.5rem;
   width: 100%;
   padding: 1.55rem 0;
   border-radius: 5px;

--- a/src/pages/onboarding/OnboardingPage.tsx
+++ b/src/pages/onboarding/OnboardingPage.tsx
@@ -16,6 +16,7 @@ import Step재직기간 from './components/seniorOnboarding/Step재직기간';
 import Step졸업인증 from './components/seniorOnboarding/Step졸업인증';
 import Step직무선택 from './components/seniorOnboarding/Step직무선택';
 import TitleBox from './components/TitleBox';
+import Step명함인증 from './components/seniorOnboarding/Step명함인증';
 
 export const StepContext = createContext({
   onNext: () => {},
@@ -43,11 +44,13 @@ const OnboardingPage = () => {
       case 6:
         return <Step졸업인증 />;
       case 7:
-        return <Step재직인증 />;
+        return <Step명함인증 />;
+      case 8:
+        return <Step인증완료 />;
       case 9:
-        return <Step재직기간 />;
-      case 10:
         return <Step직무선택 />;
+      case 10:
+        return <Step재직기간 />;
       case 11:
         return <Step번호입력 />;
     }
@@ -60,15 +63,8 @@ const OnboardingPage = () => {
         <ProgressBar max={4} current={4} />
         <Content>
           <TitleBox title="인증이 완료되었어요" description="명함 정보를 확인해 주세요" />
-          <Step인증완료 />
+          <Step인증완료 onNext={() => handleSetStep('NEXT')} />
         </Content>
-        <Caption>
-          {`현재 입력된 정보가 잘못되어 있어도 괜찮아요 !\n이후 인증 절차(전화번호)와 마이페이지(회사명)에서 수정이 가능해요`}
-        </Caption>
-        <ButtonWrapper>
-          <BlackButton>다시찍기</BlackButton>
-          <BlueButton onClick={() => handleSetStep('NEXT')}>다음으로</BlueButton>
-        </ButtonWrapper>
       </Wrapper>
     );
   }
@@ -100,48 +96,4 @@ const Content = styled.article`
 
   height: 100%;
   padding-top: 3rem;
-`;
-
-const Caption = styled.p`
-  width: 100%;
-  margin-bottom: 2rem;
-
-  color: ${({ theme }) => theme.colors.grayScaleMG2};
-  text-align: center;
-  white-space: pre-line;
-  ${({ theme }) => theme.fonts.Caption1_R_12};
-`;
-const ButtonWrapper = styled.div`
-  display: flex;
-  gap: 1rem;
-`;
-const BlackButton = styled.button`
-  width: 10.6rem;
-  height: 5.6rem;
-  padding: 1.5rem 2rem;
-  border-radius: 5px;
-
-  background-color: ${({ theme }) => theme.colors.grayScaleBG};
-
-  ${({ theme }) => theme.fonts.Head2_SB_18}
-  color: ${({ theme }) => theme.colors.grayScaleWhite};
-`;
-const BlueButton = styled.button`
-  z-index: 1;
-
-  width: 21.9rem;
-  height: 5.6rem;
-  padding: 1.55rem 7.85rem;
-  border-radius: 5px;
-
-  background-color: ${({ theme }) => theme.colors.Blue};
-
-  ${({ theme }) => theme.fonts.Head2_SB_18}
-  color: ${({ theme }) => theme.colors.grayScaleWhite};
-
-  &:disabled {
-    background-color: ${({ theme }) => theme.colors.grayScaleMG2};
-
-    cursor: default;
-  }
 `;

--- a/src/pages/onboarding/OnboardingPage.tsx
+++ b/src/pages/onboarding/OnboardingPage.tsx
@@ -45,8 +45,6 @@ const OnboardingPage = () => {
         return <Step졸업인증 />;
       case 7:
         return <Step명함인증 />;
-      case 8:
-        return <Step인증완료 />;
       case 9:
         return <Step직무선택 />;
       case 10:
@@ -86,7 +84,7 @@ const Wrapper = styled.section`
   justify-content: space-between;
 
   height: 100dvh;
-  padding: 5.8rem 2rem 3.6rem;
+  padding: 5.8rem 0 3.6rem;
 `;
 
 const Content = styled.article`
@@ -95,5 +93,5 @@ const Content = styled.article`
   gap: 2rem;
 
   height: 100%;
-  padding-top: 3rem;
+  padding: 3rem 2rem 0;
 `;

--- a/src/pages/onboarding/OnboardingPage.tsx
+++ b/src/pages/onboarding/OnboardingPage.tsx
@@ -76,7 +76,7 @@ const OnboardingPage = () => {
   return (
     <StepContext.Provider value={{ onNext: () => handleSetStep('NEXT') }}>
       <Layout userRole={role} step={step} handleSetStep={handleSetStep}>
-        <Step onNext={() => handleSetStep('NEXT')} />
+        <Step />
       </Layout>
     </StepContext.Provider>
   );

--- a/src/pages/onboarding/OnboardingPage.tsx
+++ b/src/pages/onboarding/OnboardingPage.tsx
@@ -4,7 +4,7 @@ import ProgressBar from '@components/commons/ProgressBar';
 import styled from '@emotion/styled';
 import Layout from '@pages/onboarding/components/Layout';
 import Step재직인증 from '@pages/onboarding/components/seniorOnboarding/Step재직인증';
-import { useState } from 'react';
+import { createContext, useState } from 'react';
 import Step개인정보입력 from './components/commonOnboarding/Step개인정보입력';
 import Step계열선택 from './components/commonOnboarding/Step계열선택';
 import Step번호입력 from './components/commonOnboarding/Step번호입력';
@@ -17,8 +17,11 @@ import Step졸업인증 from './components/seniorOnboarding/Step졸업인증';
 import Step직무선택 from './components/seniorOnboarding/Step직무선택';
 import TitleBox from './components/TitleBox';
 
+export const StepContext = createContext({
+  onNext: () => {},
+});
+
 const OnboardingPage = () => {
-  // 테스트
   const role = 'SENIOR';
   const [step, setStep] = useState(1);
   const handleSetStep = (dir: 'NEXT' | 'PREV') => {
@@ -71,9 +74,11 @@ const OnboardingPage = () => {
   }
 
   return (
-    <Layout userRole={role} step={step} handleSetStep={handleSetStep}>
-      <Step />
-    </Layout>
+    <StepContext.Provider value={{ onNext: () => handleSetStep('NEXT') }}>
+      <Layout userRole={role} step={step} handleSetStep={handleSetStep}>
+        <Step onNext={() => handleSetStep('NEXT')} />
+      </Layout>
+    </StepContext.Provider>
   );
 };
 

--- a/src/pages/onboarding/components/Layout.tsx
+++ b/src/pages/onboarding/components/Layout.tsx
@@ -2,7 +2,6 @@ import styled from '@emotion/styled';
 import { ReactNode } from 'react';
 import TitleBox from './TitleBox';
 import { ArrowLeftIc } from '../../../assets/svgs';
-import { FullBtn } from '../../../components/commons/FullButton';
 import { Header } from '../../../components/commons/Header';
 import ProgressBar from '../../../components/commons/ProgressBar';
 import { ONBOARDING_HEADER, SENIOR_ONBOARDING_STEPS } from '../constants';
@@ -35,7 +34,6 @@ const Layout = ({
         <TitleBox title={title} description={description} />
       </MetaContainer>
       <Content>{children}</Content>
-      <FullBtn text="텍스트" isActive onClick={() => handleSetStep('NEXT')} />
       <ButtonBg />
     </Wrapper>
   );

--- a/src/pages/onboarding/components/SelectBox.tsx
+++ b/src/pages/onboarding/components/SelectBox.tsx
@@ -3,13 +3,19 @@ import styled from '@emotion/styled';
 import { useState } from 'react';
 import { 연차_LIST } from '../constants';
 
-const SelectBox = () => {
-  const PLACEHOLDER = '연차를 선택해 주세요';
-  const [select, setSelect] = useState(PLACEHOLDER);
+const SelectBox = ({
+  select,
+  onSetSelect,
+  placeholder,
+}: {
+  select: string;
+  onSetSelect: (value: string) => void;
+  placeholder: string;
+}) => {
   const [isOpen, setIsOpen] = useState(false);
 
   const handleClickItem = (item: string) => {
-    setSelect(item);
+    onSetSelect(item);
     setIsOpen(false);
   };
 
@@ -17,7 +23,7 @@ const SelectBox = () => {
     <Wrapper>
       <SubTitle>연차</SubTitle>
       <SelectWrapper onClick={() => setIsOpen(true)}>
-        <SelectBtn $isSelected={select !== PLACEHOLDER}>{select || PLACEHOLDER}</SelectBtn>
+        <SelectBtn $isSelected={select !== placeholder}>{select || placeholder}</SelectBtn>
         <DropdownIcon />
       </SelectWrapper>
       {isOpen && (

--- a/src/pages/onboarding/components/SelectBox.tsx
+++ b/src/pages/onboarding/components/SelectBox.tsx
@@ -41,6 +41,8 @@ const Wrapper = styled.article`
   display: flex;
   flex-direction: column;
   gap: 1rem;
+
+  padding-top: 2rem;
 `;
 
 const SubTitle = styled.h2`

--- a/src/pages/onboarding/components/commonOnboarding/Step개인정보입력.tsx
+++ b/src/pages/onboarding/components/commonOnboarding/Step개인정보입력.tsx
@@ -2,10 +2,13 @@ import { StartProfile1Img, StartProfile2Img } from '@assets/images';
 import { CameraIc } from '@assets/svgs';
 import WarnDescription from '@components/commons/WarnDescription';
 import styled from '@emotion/styled';
-import { ChangeEvent, useState } from 'react';
+import { ChangeEvent, useContext, useState } from 'react';
 import { Caption, InnerButton, InputBox, TextBox } from '../TextBox';
+import { FullBtn } from '@components/commons/FullButton';
+import { StepContext } from '@pages/onboarding/OnboardingPage';
 
 const Step개인정보입력 = () => {
+  const { onNext } = useContext(StepContext);
   // setNicknamError는 추후 서버 API 통신 결과값에 따라 업데이트
   // warnText도 에러메시지에 따라 조건부렌더링 예정
   const [isNicknameError, setNicknameError] = useState(true);
@@ -46,6 +49,7 @@ const Step개인정보입력 = () => {
           <Caption>8자리 이내, 문자/숫자 가능, 특수문자/기호 입력 불가</Caption>
         )}
       </TextBox>
+      <FullBtn text="텍스트" isActive onClick={onNext} />
     </>
   );
 };

--- a/src/pages/onboarding/components/commonOnboarding/Step개인정보입력.tsx
+++ b/src/pages/onboarding/components/commonOnboarding/Step개인정보입력.tsx
@@ -11,7 +11,7 @@ const Step개인정보입력 = () => {
   const { onNext } = useContext(StepContext);
   // setNicknamError는 추후 서버 API 통신 결과값에 따라 업데이트
   // warnText도 에러메시지에 따라 조건부렌더링 예정
-  const [isNicknameError, setNicknameError] = useState(true);
+  const [isNicknameError, setNicknameError] = useState(false);
   const [imageFile, setImageFile] = useState('');
   const startImgArr = [StartProfile1Img, StartProfile2Img];
   const startImg = startImgArr[Math.floor(Math.random() * 2)];
@@ -24,6 +24,8 @@ const Step개인정보입력 = () => {
       setImageFile(reader.result as string);
     };
   };
+  // 임시 변수 (서버 통신 응답)
+  const isChecked = true;
 
   return (
     <>
@@ -49,7 +51,7 @@ const Step개인정보입력 = () => {
           <Caption>8자리 이내, 문자/숫자 가능, 특수문자/기호 입력 불가</Caption>
         )}
       </TextBox>
-      <FullBtn isActive onClick={onNext} />
+      <FullBtn isActive={isChecked} onClick={onNext} />
     </>
   );
 };

--- a/src/pages/onboarding/components/commonOnboarding/Step개인정보입력.tsx
+++ b/src/pages/onboarding/components/commonOnboarding/Step개인정보입력.tsx
@@ -49,7 +49,7 @@ const Step개인정보입력 = () => {
           <Caption>8자리 이내, 문자/숫자 가능, 특수문자/기호 입력 불가</Caption>
         )}
       </TextBox>
-      <FullBtn text="텍스트" isActive onClick={onNext} />
+      <FullBtn isActive onClick={onNext} />
     </>
   );
 };

--- a/src/pages/onboarding/components/commonOnboarding/Step계열선택.tsx
+++ b/src/pages/onboarding/components/commonOnboarding/Step계열선택.tsx
@@ -1,8 +1,12 @@
 import { CheckItemIc } from '@assets/svgs';
+import { FullBtn } from '@components/commons/FullButton';
 import styled from '@emotion/styled';
+import { StepContext } from '@pages/onboarding/OnboardingPage';
 import { 계열_LIST } from '@pages/onboarding/constants';
+import { useContext } from 'react';
 
 const Step계열선택 = () => {
+  const { onNext } = useContext(StepContext);
   return (
     <Wrapper>
       {계열_LIST.map((el) => (
@@ -14,6 +18,7 @@ const Step계열선택 = () => {
           <CheckItemIc />
         </ItemWrapper>
       ))}
+      <FullBtn text="텍스트" isActive onClick={onNext} />
     </Wrapper>
   );
 };

--- a/src/pages/onboarding/components/commonOnboarding/Step계열선택.tsx
+++ b/src/pages/onboarding/components/commonOnboarding/Step계열선택.tsx
@@ -18,7 +18,7 @@ const Step계열선택 = () => {
           <CheckItemIc />
         </ItemWrapper>
       ))}
-      <FullBtn text="텍스트" isActive onClick={onNext} />
+      <FullBtn isActive onClick={onNext} />
     </Wrapper>
   );
 };

--- a/src/pages/onboarding/components/commonOnboarding/Step계열선택.tsx
+++ b/src/pages/onboarding/components/commonOnboarding/Step계열선택.tsx
@@ -3,14 +3,15 @@ import { FullBtn } from '@components/commons/FullButton';
 import styled from '@emotion/styled';
 import { StepContext } from '@pages/onboarding/OnboardingPage';
 import { 계열_LIST } from '@pages/onboarding/constants';
-import { useContext } from 'react';
+import { useContext, useState } from 'react';
 
 const Step계열선택 = () => {
+  const [selectedField, setSelectedField] = useState('');
   const { onNext } = useContext(StepContext);
   return (
     <Wrapper>
       {계열_LIST.map((el) => (
-        <ItemWrapper key={el}>
+        <ItemWrapper key={el} onClick={() => setSelectedField(el)}>
           <Item>
             <Icon />
             {el}
@@ -18,7 +19,7 @@ const Step계열선택 = () => {
           <CheckItemIc />
         </ItemWrapper>
       ))}
-      <FullBtn isActive onClick={onNext} />
+      <FullBtn isActive={selectedField !== ''} onClick={onNext} />
     </Wrapper>
   );
 };

--- a/src/pages/onboarding/components/commonOnboarding/Step번호입력.tsx
+++ b/src/pages/onboarding/components/commonOnboarding/Step번호입력.tsx
@@ -1,6 +1,10 @@
+import { FullBtn } from '@components/commons/FullButton';
 import { InnerButton, InputBox, TextBox } from '../TextBox';
+import { useContext } from 'react';
+import { StepContext } from '@pages/onboarding/OnboardingPage';
 
 const Step번호입력 = () => {
+  const { onNext } = useContext(StepContext);
   return (
     <>
       <TextBox label="">
@@ -9,6 +13,7 @@ const Step번호입력 = () => {
         </InputBox>
         <InputBox label="인증번호" placeholder="전송된 4자리 코드를 입력해 주세요" />
       </TextBox>
+      <FullBtn text="텍스트" isActive onClick={onNext} />
     </>
   );
 };

--- a/src/pages/onboarding/components/commonOnboarding/Step번호입력.tsx
+++ b/src/pages/onboarding/components/commonOnboarding/Step번호입력.tsx
@@ -2,11 +2,12 @@ import { FullBtn } from '@components/commons/FullButton';
 import { InnerButton, InputBox, TextBox } from '../TextBox';
 import { useContext } from 'react';
 import { StepContext } from '@pages/onboarding/OnboardingPage';
+import styled from '@emotion/styled';
 
 const Step번호입력 = () => {
   const { onNext } = useContext(StepContext);
   return (
-    <>
+    <Wrapper>
       <TextBox label="">
         <InputBox label="폰번호" placeholder="전화번호를 입력해 주세요">
           <InnerButton text="인증번호 전송" />
@@ -14,8 +15,12 @@ const Step번호입력 = () => {
         <InputBox label="인증번호" placeholder="전송된 4자리 코드를 입력해 주세요" />
       </TextBox>
       <FullBtn text="인증 확인" isActive onClick={onNext} />
-    </>
+    </Wrapper>
   );
 };
 
 export default Step번호입력;
+
+const Wrapper = styled.div`
+  padding-top: 2rem;
+`;

--- a/src/pages/onboarding/components/commonOnboarding/Step번호입력.tsx
+++ b/src/pages/onboarding/components/commonOnboarding/Step번호입력.tsx
@@ -13,7 +13,7 @@ const Step번호입력 = () => {
         </InputBox>
         <InputBox label="인증번호" placeholder="전송된 4자리 코드를 입력해 주세요" />
       </TextBox>
-      <FullBtn text="텍스트" isActive onClick={onNext} />
+      <FullBtn text="인증 확인" isActive onClick={onNext} />
     </>
   );
 };

--- a/src/pages/onboarding/components/commonOnboarding/Step번호입력.tsx
+++ b/src/pages/onboarding/components/commonOnboarding/Step번호입력.tsx
@@ -6,6 +6,10 @@ import styled from '@emotion/styled';
 
 const Step번호입력 = () => {
   const { onNext } = useContext(StepContext);
+  // 임시 변수
+  const VERIFICATION_CODE = '0000';
+  const USER_INPUT = '0000';
+
   return (
     <Wrapper>
       <TextBox label="">
@@ -14,7 +18,7 @@ const Step번호입력 = () => {
         </InputBox>
         <InputBox label="인증번호" placeholder="전송된 4자리 코드를 입력해 주세요" />
       </TextBox>
-      <FullBtn text="인증 확인" isActive onClick={onNext} />
+      <FullBtn text="인증 확인" isActive={USER_INPUT === VERIFICATION_CODE} onClick={onNext} />
     </Wrapper>
   );
 };

--- a/src/pages/onboarding/components/commonOnboarding/Step약관동의.tsx
+++ b/src/pages/onboarding/components/commonOnboarding/Step약관동의.tsx
@@ -45,7 +45,11 @@ const Step약관동의 = () => {
           </ItemWrapper>
         </li>
       ))}
-      <FullBtn text="동의하기" isActive onClick={onNext} />
+      <FullBtn
+        text="동의하기"
+        isActive={agreement[0] && agreement[1] && agreement[2] && agreement[3]}
+        onClick={onNext}
+      />
     </Wrapper>
   );
 };
@@ -55,6 +59,8 @@ export default Step약관동의;
 const Wrapper = styled.ul`
   display: flex;
   flex-direction: column;
+
+  padding-top: 1.3rem;
 `;
 
 const ItemWrapper = styled.button`

--- a/src/pages/onboarding/components/commonOnboarding/Step약관동의.tsx
+++ b/src/pages/onboarding/components/commonOnboarding/Step약관동의.tsx
@@ -45,7 +45,7 @@ const Step약관동의 = () => {
           </ItemWrapper>
         </li>
       ))}
-      <FullBtn text="텍스트" isActive onClick={onNext} />
+      <FullBtn text="동의하기" isActive onClick={onNext} />
     </Wrapper>
   );
 };

--- a/src/pages/onboarding/components/commonOnboarding/Step약관동의.tsx
+++ b/src/pages/onboarding/components/commonOnboarding/Step약관동의.tsx
@@ -1,10 +1,13 @@
 import { ArrowRightIc, CheckItemIc } from '@assets/svgs';
+import { FullBtn } from '@components/commons/FullButton';
 import styled from '@emotion/styled';
+import { StepContext } from '@pages/onboarding/OnboardingPage';
 import { 약관_LIST } from '@pages/onboarding/constants';
-import { useState } from 'react';
+import { useContext, useState } from 'react';
 import { Link } from 'react-router-dom';
 
 const Step약관동의 = () => {
+  const { onNext } = useContext(StepContext);
   const [agreement, setAgreement] = useState([false, false, false, false, false]);
 
   const handleClickCheck = (id: number | 'all') => {
@@ -42,6 +45,7 @@ const Step약관동의 = () => {
           </ItemWrapper>
         </li>
       ))}
+      <FullBtn text="텍스트" isActive onClick={onNext} />
     </Wrapper>
   );
 };

--- a/src/pages/onboarding/components/commonOnboarding/Step약관동의.tsx
+++ b/src/pages/onboarding/components/commonOnboarding/Step약관동의.tsx
@@ -8,12 +8,12 @@ import { Link } from 'react-router-dom';
 
 const Step약관동의 = () => {
   const { onNext } = useContext(StepContext);
-  const [agreement, setAgreement] = useState([false, false, false, false, false]);
+  const [agreement, setAgreement] = useState(Array(5).fill(false));
 
   const handleClickCheck = (id: number | 'all') => {
     if (id === 'all') {
-      if (!agreement.some((v) => !v)) setAgreement([false, false, false, false, false]);
-      else setAgreement([true, true, true, true, true]);
+      if (!agreement.some((v) => !v)) setAgreement(Array(5).fill(false));
+      else setAgreement(Array(5).fill(true));
     } else {
       setAgreement((prev) => agreement.with(id, !prev[id]));
     }

--- a/src/pages/onboarding/components/commonOnboarding/Step학과선택.tsx
+++ b/src/pages/onboarding/components/commonOnboarding/Step학과선택.tsx
@@ -127,6 +127,6 @@ const MajorText = styled.p<{ $isActive: boolean }>`
   ${({ theme }) => theme.fonts.Body3_SB_14};
 `;
 
-const IconWrapper = styled(CheckItemIc)<{ $isActive: boolean }>`
+const IconWrapper = styled.i<{ $isActive: boolean }>`
   fill: ${({ theme, $isActive }) => ($isActive ? theme.colors.Blue : '')};
 `;

--- a/src/pages/onboarding/components/commonOnboarding/Step학과선택.tsx
+++ b/src/pages/onboarding/components/commonOnboarding/Step학과선택.tsx
@@ -27,11 +27,11 @@ const Step학과선택 = () => {
   };
 
   useEffect(() => {
-    if (selectedMajors.length > 3) {
+    if (selectedMajors.length > 0) {
       setSelectedMajors((prev) => prev.slice(0, 3));
       setIsExceed(true);
     }
-    if (selectedMajors.length < 3) {
+    if (selectedMajors.length < 2) {
       setIsExceed(false);
     }
   }, [selectedMajors]);
@@ -57,7 +57,7 @@ const Step학과선택 = () => {
           <SearchList key={m} handleSelectMajors={handleSelectMajors} majorName={m} selectedMajors={selectedMajors} />
         ))}
       </SearchListWrapper>
-      <FullBtn isActive onClick={onNext} />
+      <FullBtn isActive={selectedMajors.length > 0} onClick={onNext} />
     </Wrapper>
   );
 };

--- a/src/pages/onboarding/components/commonOnboarding/Step학과선택.tsx
+++ b/src/pages/onboarding/components/commonOnboarding/Step학과선택.tsx
@@ -2,10 +2,13 @@ import { CheckItemIc } from '@assets/svgs';
 import WarnDescription from '@components/commons/WarnDescription';
 import styled from '@emotion/styled';
 import MajorChip from '@pages/onboarding/components/MajorChip';
-import { useEffect, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import SearchBox from '../SearchBox';
+import { FullBtn } from '@components/commons/FullButton';
+import { StepContext } from '@pages/onboarding/OnboardingPage';
 
 const Step학과선택 = () => {
+  const { onNext } = useContext(StepContext);
   const [searchValue, setSearchValue] = useState('');
   const [selectedMajors, setSelectedMajors] = useState<string[]>([]);
   const [isExceed, setIsExceed] = useState(false);
@@ -54,6 +57,7 @@ const Step학과선택 = () => {
           <SearchList key={m} handleSelectMajors={handleSelectMajors} majorName={m} selectedMajors={selectedMajors} />
         ))}
       </SearchListWrapper>
+      <FullBtn text="텍스트" isActive onClick={onNext} />
     </Wrapper>
   );
 };

--- a/src/pages/onboarding/components/commonOnboarding/Step학과선택.tsx
+++ b/src/pages/onboarding/components/commonOnboarding/Step학과선택.tsx
@@ -57,7 +57,7 @@ const Step학과선택 = () => {
           <SearchList key={m} handleSelectMajors={handleSelectMajors} majorName={m} selectedMajors={selectedMajors} />
         ))}
       </SearchListWrapper>
-      <FullBtn text="텍스트" isActive onClick={onNext} />
+      <FullBtn isActive onClick={onNext} />
     </Wrapper>
   );
 };

--- a/src/pages/onboarding/components/commonOnboarding/Step학과선택.tsx
+++ b/src/pages/onboarding/components/commonOnboarding/Step학과선택.tsx
@@ -103,7 +103,9 @@ const SearchList = ({ handleSelectMajors, majorName, selectedMajors }: searchLis
   return (
     <SearchListContainer onClick={handleClick}>
       <MajorText $isActive={isActive}>{majorName}</MajorText>
-      <CheckItemIcon $isActive={isActive} />
+      <IconWrapper $isActive={isActive}>
+        <CheckItemIc />
+      </IconWrapper>
     </SearchListContainer>
   );
 };
@@ -125,6 +127,6 @@ const MajorText = styled.p<{ $isActive: boolean }>`
   ${({ theme }) => theme.fonts.Body3_SB_14};
 `;
 
-const CheckItemIcon = styled(CheckItemIc)<{ $isActive: boolean }>`
+const IconWrapper = styled(CheckItemIc)<{ $isActive: boolean }>`
   fill: ${({ theme, $isActive }) => ($isActive ? theme.colors.Blue : '')};
 `;

--- a/src/pages/onboarding/components/commonOnboarding/Step학교선택.tsx
+++ b/src/pages/onboarding/components/commonOnboarding/Step학교선택.tsx
@@ -23,7 +23,7 @@ const Step학교선택 = () => {
           <Sheet학교선택 handleSelectUniv={handleSelectUniv} />
         </BottomSheet>
       )}
-      <FullBtn text="텍스트" isActive onClick={onNext} />
+      <FullBtn isActive onClick={onNext} />
     </Wrapper>
   );
 };

--- a/src/pages/onboarding/components/commonOnboarding/Step학교선택.tsx
+++ b/src/pages/onboarding/components/commonOnboarding/Step학교선택.tsx
@@ -23,7 +23,7 @@ const Step학교선택 = () => {
           <Sheet학교선택 handleSelectUniv={handleSelectUniv} />
         </BottomSheet>
       )}
-      <FullBtn isActive onClick={onNext} />
+      <FullBtn isActive={selectedUniv !== ''} onClick={onNext} />
     </Wrapper>
   );
 };

--- a/src/pages/onboarding/components/commonOnboarding/Step학교선택.tsx
+++ b/src/pages/onboarding/components/commonOnboarding/Step학교선택.tsx
@@ -1,10 +1,13 @@
 import styled from '@emotion/styled';
 import BottomSheet from '@pages/onboarding/components/BottomSheet';
 import { excludeCommonPart } from '@pages/onboarding/utils/excludeCommonPart';
-import { useState } from 'react';
+import { useContext, useState } from 'react';
 import SearchBox from '../SearchBox';
+import { StepContext } from '@pages/onboarding/OnboardingPage';
+import { FullBtn } from '@components/commons/FullButton';
 
 const Step학교선택 = () => {
+  const { onNext } = useContext(StepContext);
   const [isOpenSheet, setIsOpenSheet] = useState(false);
   const [selectedUniv, setSelectedUniv] = useState('');
   const handleOpenSheet = () => setIsOpenSheet(true);
@@ -20,6 +23,7 @@ const Step학교선택 = () => {
           <Sheet학교선택 handleSelectUniv={handleSelectUniv} />
         </BottomSheet>
       )}
+      <FullBtn text="텍스트" isActive onClick={onNext} />
     </Wrapper>
   );
 };

--- a/src/pages/onboarding/components/seniorOnboarding/Step명함인증.tsx
+++ b/src/pages/onboarding/components/seniorOnboarding/Step명함인증.tsx
@@ -20,6 +20,8 @@ const Wrapper = styled.section`
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+
+  padding-top: 2rem;
 `;
 const Image = styled.div`
   width: 100%;

--- a/src/pages/onboarding/components/seniorOnboarding/Step명함인증.tsx
+++ b/src/pages/onboarding/components/seniorOnboarding/Step명함인증.tsx
@@ -9,7 +9,7 @@ const Step명함인증 = () => {
     <Wrapper>
       <Image />
       <Caption>재직 사실 확인을 위해 명함 촬영이 필요해요</Caption>
-      <FullBtn text="텍스트" isActive onClick={onNext} />
+      <FullBtn text="명함 촬영하기" isActive onClick={onNext} />
     </Wrapper>
   );
 };

--- a/src/pages/onboarding/components/seniorOnboarding/Step명함인증.tsx
+++ b/src/pages/onboarding/components/seniorOnboarding/Step명함인증.tsx
@@ -1,10 +1,15 @@
+import { FullBtn } from '@components/commons/FullButton';
 import styled from '@emotion/styled';
+import { StepContext } from '@pages/onboarding/OnboardingPage';
+import { useContext } from 'react';
 
 const Step명함인증 = () => {
+  const { onNext } = useContext(StepContext);
   return (
     <Wrapper>
       <Image />
       <Caption>재직 사실 확인을 위해 명함 촬영이 필요해요</Caption>
+      <FullBtn text="텍스트" isActive onClick={onNext} />
     </Wrapper>
   );
 };

--- a/src/pages/onboarding/components/seniorOnboarding/Step인증완료.tsx
+++ b/src/pages/onboarding/components/seniorOnboarding/Step인증완료.tsx
@@ -1,10 +1,8 @@
-import { useContext } from 'react';
 import { InputBox, TextBox } from '../TextBox';
-import { StepContext } from '@pages/onboarding/OnboardingPage';
-import { FullBtn } from '@components/commons/FullButton';
 
-const Step인증완료 = () => {
-  const { onNext } = useContext(StepContext);
+import styled from '@emotion/styled';
+
+const Step인증완료 = ({ onNext }: { onNext: () => void }) => {
   const company = '네이버';
   const phoneNum = '전화번호';
 
@@ -16,9 +14,72 @@ const Step인증완료 = () => {
       <TextBox label="전화번호">
         <InputBox label="전화번호" placeholder="닉네임을 입력해주세요" value={phoneNum} />
       </TextBox>
-      <FullBtn text="텍스트" isActive onClick={onNext} />
+      <Caption>
+        {`현재 입력된 정보가 잘못되어 있어도 괜찮아요 !\n이후 인증 절차(전화번호)와 마이페이지(회사명)에서 수정이 가능해요`}
+      </Caption>
+      <ButtonWrapper>
+        <BlackButton type="button">다시찍기</BlackButton>
+        <BlueButton type="button" onClick={onNext}>
+          다음으로
+        </BlueButton>
+      </ButtonWrapper>
     </>
   );
 };
 
 export default Step인증완료;
+
+const ButtonWrapper = styled.div`
+  display: flex;
+  gap: 1rem;
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  z-index: 9;
+
+  width: 100%;
+  padding: 3.6rem 2rem;
+`;
+
+const BlackButton = styled.button`
+  flex-grow: 1;
+
+  padding: 1.5rem 0;
+  border-radius: 5px;
+
+  background-color: ${({ theme }) => theme.colors.grayScaleBG};
+
+  ${({ theme }) => theme.fonts.Head2_SB_18}
+  color: ${({ theme }) => theme.colors.grayScaleWhite};
+`;
+const BlueButton = styled.button`
+  flex-grow: 1;
+
+  padding: 1.55rem 0;
+  border-radius: 5px;
+
+  background-color: ${({ theme }) => theme.colors.Blue};
+
+  ${({ theme }) => theme.fonts.Head2_SB_18}
+  color: ${({ theme }) => theme.colors.grayScaleWhite};
+
+  &:disabled {
+    background-color: ${({ theme }) => theme.colors.grayScaleMG2};
+
+    cursor: default;
+  }
+`;
+
+const Caption = styled.p`
+  position: fixed;
+  bottom: 0;
+  left: 0;
+
+  width: 100%;
+  margin-bottom: 11.2rem;
+
+  color: ${({ theme }) => theme.colors.grayScaleMG2};
+  text-align: center;
+  white-space: pre-line;
+  ${({ theme }) => theme.fonts.Caption1_R_12};
+`;

--- a/src/pages/onboarding/components/seniorOnboarding/Step인증완료.tsx
+++ b/src/pages/onboarding/components/seniorOnboarding/Step인증완료.tsx
@@ -1,6 +1,10 @@
+import { useContext } from 'react';
 import { InputBox, TextBox } from '../TextBox';
+import { StepContext } from '@pages/onboarding/OnboardingPage';
+import { FullBtn } from '@components/commons/FullButton';
 
 const Step인증완료 = () => {
+  const { onNext } = useContext(StepContext);
   const company = '네이버';
   const phoneNum = '전화번호';
 
@@ -12,6 +16,7 @@ const Step인증완료 = () => {
       <TextBox label="전화번호">
         <InputBox label="전화번호" placeholder="닉네임을 입력해주세요" value={phoneNum} />
       </TextBox>
+      <FullBtn text="텍스트" isActive onClick={onNext} />
     </>
   );
 };

--- a/src/pages/onboarding/components/seniorOnboarding/Step재직기간.tsx
+++ b/src/pages/onboarding/components/seniorOnboarding/Step재직기간.tsx
@@ -8,7 +8,7 @@ const Step재직기간 = () => {
   return (
     <>
       <SelectBox />
-      <FullBtn text="텍스트" isActive onClick={onNext} />
+      <FullBtn isActive onClick={onNext} />
     </>
   );
 };

--- a/src/pages/onboarding/components/seniorOnboarding/Step재직기간.tsx
+++ b/src/pages/onboarding/components/seniorOnboarding/Step재직기간.tsx
@@ -1,7 +1,16 @@
+import { useContext } from 'react';
 import SelectBox from '../SelectBox';
+import { StepContext } from '@pages/onboarding/OnboardingPage';
+import { FullBtn } from '@components/commons/FullButton';
 
 const Step재직기간 = () => {
-  return <SelectBox />;
+  const { onNext } = useContext(StepContext);
+  return (
+    <>
+      <SelectBox />
+      <FullBtn text="텍스트" isActive onClick={onNext} />
+    </>
+  );
 };
 
 export default Step재직기간;

--- a/src/pages/onboarding/components/seniorOnboarding/Step재직기간.tsx
+++ b/src/pages/onboarding/components/seniorOnboarding/Step재직기간.tsx
@@ -1,14 +1,21 @@
-import { useContext } from 'react';
+import { useContext, useState } from 'react';
 import SelectBox from '../SelectBox';
 import { StepContext } from '@pages/onboarding/OnboardingPage';
 import { FullBtn } from '@components/commons/FullButton';
 
 const Step재직기간 = () => {
+  const PLACEHOLDER = '연차를 선택해 주세요';
+  const [select, setSelect] = useState(PLACEHOLDER);
   const { onNext } = useContext(StepContext);
+
+  const handleSetSelect = (value: string) => {
+    setSelect(value);
+  };
+
   return (
     <>
-      <SelectBox />
-      <FullBtn isActive onClick={onNext} />
+      <SelectBox select={select} onSetSelect={handleSetSelect} placeholder={PLACEHOLDER} />
+      <FullBtn isActive={select !== ''} onClick={onNext} />
     </>
   );
 };

--- a/src/pages/onboarding/components/seniorOnboarding/Step재직인증.tsx
+++ b/src/pages/onboarding/components/seniorOnboarding/Step재직인증.tsx
@@ -6,7 +6,7 @@ import { 세부직무_DESCRIPTION, 세부직무_LIST } from '@pages/onboarding/c
 import { useContext, useState } from 'react';
 
 // 임시코드임니다 승희언니가 갈아끼울 예정이에오
-const Step재직인증 = () => {
+const Step직무선택 = () => {
   const [isOpenSheet, setIsOpenSheet] = useState(false);
   const [selectedDetails, setSelectedDetails] = useState<string[]>([]);
   const handleOpenSheet = () => setIsOpenSheet(true);
@@ -27,12 +27,11 @@ const Step재직인증 = () => {
           <Sheet재직인증 handleSelectDetails={handleSelectDetails} />
         </BottomSheet>
       )}
-      <FullBtn text="텍스트" isActive onClick={onNext} />
     </>
   );
 };
 
-export default Step재직인증;
+export default Step직무선택;
 
 interface Sheet재직인증PropType {
   // eslint-disable-next-line no-unused-vars

--- a/src/pages/onboarding/components/seniorOnboarding/Step재직인증.tsx
+++ b/src/pages/onboarding/components/seniorOnboarding/Step재직인증.tsx
@@ -1,7 +1,9 @@
+import { FullBtn } from '@components/commons/FullButton';
 import styled from '@emotion/styled';
+import { StepContext } from '@pages/onboarding/OnboardingPage';
 import BottomSheet from '@pages/onboarding/components/BottomSheet';
 import { 세부직무_DESCRIPTION, 세부직무_LIST } from '@pages/onboarding/constants';
-import { useState } from 'react';
+import { useContext, useState } from 'react';
 
 // 임시코드임니다 승희언니가 갈아끼울 예정이에오
 const Step재직인증 = () => {
@@ -14,6 +16,7 @@ const Step재직인증 = () => {
       prev?.includes(selectedValue) ? prev.filter((detail) => detail !== selectedValue) : [...prev, selectedValue],
     );
   };
+  const { onNext } = useContext(StepContext);
   return (
     <>
       <div style={{ marginTop: '10rem' }}>
@@ -24,6 +27,7 @@ const Step재직인증 = () => {
           <Sheet재직인증 handleSelectDetails={handleSelectDetails} />
         </BottomSheet>
       )}
+      <FullBtn text="텍스트" isActive onClick={onNext} />
     </>
   );
 };

--- a/src/pages/onboarding/components/seniorOnboarding/Step졸업인증.tsx
+++ b/src/pages/onboarding/components/seniorOnboarding/Step졸업인증.tsx
@@ -6,6 +6,9 @@ import { StepContext } from '@pages/onboarding/OnboardingPage';
 
 const Step졸업인증 = () => {
   const { onNext } = useContext(StepContext);
+  // 임시 변수 : 서버 통신 결과에 따라
+  const isSucceed = true;
+
   return (
     <Wrapper>
       <TextBox label="졸업증명서">
@@ -14,7 +17,7 @@ const Step졸업인증 = () => {
         </InputBox>
         <Caption>JPEG, JPG, PNG, PDF 형식만 첨부 가능해요 (최대 50BM)</Caption>
       </TextBox>
-      <FullBtn text="인증하기" isActive onClick={onNext} />
+      <FullBtn text="인증하기" isActive={isSucceed} onClick={onNext} />
     </Wrapper>
   );
 };

--- a/src/pages/onboarding/components/seniorOnboarding/Step졸업인증.tsx
+++ b/src/pages/onboarding/components/seniorOnboarding/Step졸업인증.tsx
@@ -1,7 +1,11 @@
 import styled from '@emotion/styled';
 import { Caption, InnerButton, InputBox, TextBox } from '../TextBox';
+import { FullBtn } from '@components/commons/FullButton';
+import { useContext } from 'react';
+import { StepContext } from '@pages/onboarding/OnboardingPage';
 
 const Step졸업인증 = () => {
+  const { onNext } = useContext(StepContext);
   return (
     <Wrapper>
       <TextBox label="졸업증명서">
@@ -10,6 +14,7 @@ const Step졸업인증 = () => {
         </InputBox>
         <Caption>JPEG, JPG, PNG, PDF 형식만 첨부 가능해요 (최대 50BM)</Caption>
       </TextBox>
+      <FullBtn text="텍스트" isActive onClick={onNext} />
     </Wrapper>
   );
 };

--- a/src/pages/onboarding/components/seniorOnboarding/Step졸업인증.tsx
+++ b/src/pages/onboarding/components/seniorOnboarding/Step졸업인증.tsx
@@ -14,7 +14,7 @@ const Step졸업인증 = () => {
         </InputBox>
         <Caption>JPEG, JPG, PNG, PDF 형식만 첨부 가능해요 (최대 50BM)</Caption>
       </TextBox>
-      <FullBtn text="텍스트" isActive onClick={onNext} />
+      <FullBtn text="인증하기" isActive onClick={onNext} />
     </Wrapper>
   );
 };

--- a/src/pages/onboarding/components/seniorOnboarding/Step직무선택.tsx
+++ b/src/pages/onboarding/components/seniorOnboarding/Step직무선택.tsx
@@ -8,7 +8,7 @@ import { StepContext } from '@pages/onboarding/OnboardingPage';
 const Step직무선택 = () => {
   const { onNext } = useContext(StepContext);
   return (
-    <>
+    <Container>
       <Wrapper>
         <SubTitle>직무</SubTitle>
         <SelectWrapper onClick={() => console.log('열기')}>
@@ -21,16 +21,23 @@ const Step직무선택 = () => {
         <Caption>재직 중인 회사에서의 구체적인 직무를 작성해 주세요</Caption>
       </TextBox>
       <FullBtn isActive onClick={onNext} />
-    </>
+    </Container>
   );
 };
 
 export default Step직무선택;
 
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+`;
 const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 1rem;
+
+  padding-top: 2rem;
 `;
 const SubTitle = styled.h2`
   ${({ theme }) => theme.fonts.Title1_SB_16};

--- a/src/pages/onboarding/components/seniorOnboarding/Step직무선택.tsx
+++ b/src/pages/onboarding/components/seniorOnboarding/Step직무선택.tsx
@@ -1,8 +1,12 @@
 import { DropdownIc } from '@assets/svgs';
 import styled from '@emotion/styled';
 import { Caption, InputBox, TextBox } from '../TextBox';
+import { FullBtn } from '@components/commons/FullButton';
+import { useContext } from 'react';
+import { StepContext } from '@pages/onboarding/OnboardingPage';
 
 const Step직무선택 = () => {
+  const { onNext } = useContext(StepContext);
   return (
     <>
       <Wrapper>
@@ -16,6 +20,7 @@ const Step직무선택 = () => {
         <InputBox label="세부 직무" placeholder="Product Designer & Prdouct Manager"></InputBox>
         <Caption>재직 중인 회사에서의 구체적인 직무를 작성해 주세요</Caption>
       </TextBox>
+      <FullBtn text="텍스트" isActive onClick={onNext} />
     </>
   );
 };

--- a/src/pages/onboarding/components/seniorOnboarding/Step직무선택.tsx
+++ b/src/pages/onboarding/components/seniorOnboarding/Step직무선택.tsx
@@ -20,7 +20,7 @@ const Step직무선택 = () => {
         <InputBox label="세부 직무" placeholder="Product Designer & Prdouct Manager"></InputBox>
         <Caption>재직 중인 회사에서의 구체적인 직무를 작성해 주세요</Caption>
       </TextBox>
-      <FullBtn text="텍스트" isActive onClick={onNext} />
+      <FullBtn isActive onClick={onNext} />
     </>
   );
 };


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #67 

## ✅ Done Task
  - [x] CTA 호출 위치 Layout에서 각 Step 컴포넌트 내부로 이동 
  - [x] 그 과정에서 꺠진 레이아웃 및 소소한 버그 수정 
  - [x] CTA 라이팅 반영 
  - [x] CTA 활성화 여부 조건부 구현 


## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->
```
1. 약관동의 : 필수 약관 체크 박스가 모두 채워졌을 때 
2. 개인정보입력 : 닉네임 중복 확인 결과 적절한 닉네임이면 활성화
3. 학교선택 : 학교 선택 완료 시 활성화
4. 계열선택 : 계열 1개 체크 시 활성화
5. 학과선택 :  최소 1개 학과 선택 완료시 활성화
6. 졸업인증 : 적절한 파일 첨부 완료 시 활성화
7. 명함인증 : 활성화 
8. 인증완료 : 둘다 활성화 
9. 직무선택 : 직무 선택 시 활성화
10. 재직기한 : 연차 선택 시 활성화
11. 번호입력 : 5번 필드에 고객이 인증 코드 4자리 입력하면 활성화
```
이렇게 CTA 활성화 조건인데, 서버 통신 결과에 따라 보여지는 애들이 있어서 임시 변수 만들어서 두었습니다. 


## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->

뒷단계는 대부분 서버통신이랑 연관되어있어서, 일단 어거지로 구현할 수 있는 부분만 했어요!!

https://github.com/user-attachments/assets/303ded3c-4031-4bb1-86a4-7df15924208d

