### PR TITLE
[ Fix ] 학과 검색 뷰 고도화 

### DIFF
--- a/src/pages/onboarding/components/commonOnboarding/Step번호입력.tsx
+++ b/src/pages/onboarding/components/commonOnboarding/Step번호입력.tsx
@@ -1,5 +1,4 @@
 import { FullBtn } from '@components/commons/FullButton';
-import styled from '@emotion/styled';
 import { useState, useEffect } from 'react';
 import { formatTime } from '../../utils/formatTime';
 import { InnerButton, InputBox, TextBox } from '../TextBox';
@@ -62,10 +61,10 @@ export default Step번호입력;
 
 const Wrapper = styled.div`
   padding-top: 2rem;
+`;
 
 const Timer = styled.div`
   position: absolute;
-
   right: 1.5rem;
   bottom: 1.45rem;
 

--- a/src/pages/onboarding/components/commonOnboarding/Step학과선택.tsx
+++ b/src/pages/onboarding/components/commonOnboarding/Step학과선택.tsx
@@ -17,9 +17,10 @@ const Step학과선택 = () => {
   };
 
   const handleSelectMajors = (selectedValue: string) => {
-    setSelectedMajors((prev) =>
-      prev?.includes(selectedValue) ? prev.filter((detail) => detail !== selectedValue) : [...prev, selectedValue],
-    );
+    // setSelectedMajors((prev) =>
+    //   prev?.includes(selectedValue) ? prev.filter((detail) => detail !== selectedValue) : [...prev, selectedValue],
+    // );
+    setSelectedMajors([selectedValue]);
   };
 
   const handleChipClose = (deleteMajor: string) => {
@@ -28,10 +29,9 @@ const Step학과선택 = () => {
 
   useEffect(() => {
     if (selectedMajors.length > 0) {
-      setSelectedMajors((prev) => prev.slice(0, 3));
       setIsExceed(true);
     }
-    if (selectedMajors.length < 2) {
+    if (selectedMajors.length < 1) {
       setIsExceed(false);
     }
   }, [selectedMajors]);
@@ -40,16 +40,16 @@ const Step학과선택 = () => {
   return (
     <Wrapper>
       {selectedMajors.length > 0 && (
-        <ChipWrapper>
-          {selectedMajors.map((sm) => (
-            <MajorChip key={sm} major={sm} handleClose={handleChipClose} />
-          ))}
-        </ChipWrapper>
-      )}
-      {isExceed && (
-        <WarnWrapper>
-          <WarnDescription isShown={isExceed} warnText="학과는 최대 3개 선택할 수 있어요." />
-        </WarnWrapper>
+        <>
+          <ChipWrapper>
+            {selectedMajors.slice(0, 1).map((sm) => (
+              <MajorChip key={sm} major={sm} handleClose={handleChipClose} />
+            ))}
+          </ChipWrapper>
+          <WarnWrapper>
+            <WarnDescription isShown={isExceed} warnText="학과는 최대 1개 선택할 수 있어요." />
+          </WarnWrapper>
+        </>
       )}
       <SearchBox placeholder="학과명을 입력해 주세요" searchValue={searchValue} handleSearchValue={handleSearchValue} />
       <SearchListWrapper>

--- a/src/pages/onboarding/components/seniorOnboarding/Step졸업인증.tsx
+++ b/src/pages/onboarding/components/seniorOnboarding/Step졸업인증.tsx
@@ -39,6 +39,7 @@ const Step졸업인증 = () => {
             <Caption>JPEG, JPG, PNG, PDF 형식만 첨부 가능해요 (최대 50MB)</Caption>
           )}
         </TextBox>
+        <FullBtn text="텍스트" isActive={fileName !== DEFAULT_TEXT} onClick={onNext} />
       </Wrapper>
 
       <ModalWrapper>

--- a/src/pages/onboarding/constants.ts
+++ b/src/pages/onboarding/constants.ts
@@ -17,7 +17,7 @@ export const SENIOR_ONBOARDING_STEPS = [
   },
   {
     title: '학과를 선택해주세요',
-    description: '주전공과 부전공을 선택해주세요 ! ( 최대 3개 )',
+    description: '주 전공을 검색 후 선택해 주세요',
   },
   {
     title: '졸업 사실을 인증해주세요',


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #113 

## ✅ Done Task
  - [x] 무한 워닝 에러 해결 
  - [x] Step번호입력 conflict 문제 해결 
  - [x] 기능 수정사항 반영 

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->
### 기능 수정 사항 
학과 최대 선택 가능 개수가 3개였는데, 1개로 줄었어요. 
이에 따라 관련된 라이팅 수정하였습니다. 

### 무한 워닝 에러 
기존에는 칩 하나를 클릭하면 콘솔에 미친듯이 워닝이 떴어요 (수백개 우다다다다다) 
그 이유는 의존성 배열에 `selectedMajors`가 있는데, useEffect 내부에서 또 `selectedMajors`를 setState 시켜주고 있어서 무한 렌더링이 발생하는 문제였습니다. 
따라서 useEffect 내부에서 업데이트 시켜주고 있던 코드를 지워주고 정상 작동하도록 정리 좀 해줬습니다. 

추가로, 기존에는 칩이 생겼다가 사라졌다가 할 때 워닝 텍스트가 보기 좋지 않게 깜빡였는데, 
이부분도 조건부 렌더링 영역을 수정해줌으로써 해결해서 깔끔하게 생겼다/사라지도록 수정했습니다. 


## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->

https://github.com/user-attachments/assets/5f8f1651-b520-4174-bd57-6cc562fe9f03

