### PR TITLE
[ fix ] SeniorCard 레이아웃 조정

### DIFF
--- a/src/components/commons/seniorCard/SeniorCard.tsx
+++ b/src/components/commons/seniorCard/SeniorCard.tsx
@@ -23,20 +23,22 @@ export const SeniorCard = (props: seniorListPropType) => {
   return (
     <SeniorCardWrapper $isSmall={variant === 'secondary'}>
       <SeniorCardLayout>
-        <Nickname>{nickname}</Nickname>
-        <SeniorInfo>
-          <Company $randomColor={randomColor}>{company}</Company>
+        <SeniorImgWrapper>
           <SeniorImg $isSmall={variant === 'secondary'} src={image} alt="프로필 사진" />
-          <Field>{field}</Field>
-        </SeniorInfo>
-        <SeniorJob>
-          <Position>{position}</Position>
-          <Divider />
-          <DetailPosition>{detailPosition}</DetailPosition>
-        </SeniorJob>
-        <Level>
-          {levelName} ({level})
-        </Level>
+        </SeniorImgWrapper>
+        <SeniorContent>
+          <Nickname>{nickname}</Nickname>
+          <SeniorInfo>
+            <Company $randomColor={randomColor}>{company}</Company>
+            <Field>{field}</Field>
+          </SeniorInfo>
+          <SeniorJob>
+            {position}
+            <Divider />
+            {detailPosition}
+            {levelName} ({level})
+          </SeniorJob>
+        </SeniorContent>
       </SeniorCardLayout>
     </SeniorCardWrapper>
   );
@@ -46,25 +48,42 @@ export default SeniorCard;
 
 const SeniorCardWrapper = styled.div<{ $isSmall: boolean }>`
   display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: center;
+
+  width: 100%;
+  border-radius: 8px;
+
+  background: ${({ theme }) => theme.colors.grayScaleWhite};
+`;
+
+const SeniorCardLayout = styled.div`
+  display: flex;
   gap: 1.5rem;
   justify-content: center;
   align-items: center;
 
   width: 100%;
-  height: ${({ $isSmall }) => ($isSmall ? '12.6rem' : '14.2rem')};
-  border-radius: 8px;
-
-  background: ${({ theme }) => theme.colors.grayScaleWhite};
+  height: 12.6rem;
 `;
+
+const SeniorImgWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
 const SeniorImg = styled.img<{ $isSmall: boolean }>`
   width: ${({ $isSmall }) => ($isSmall ? '8.8rem' : '11.4rem')};
   height: ${({ $isSmall }) => ($isSmall ? '8.8rem' : '11.4rem')};
   border-radius: 112.82px;
 `;
 
-const SeniorCardLayout = styled.div`
+const SeniorContent = styled.div`
   display: flex;
   flex-direction: column;
+  gap: 0.5rem;
 `;
 
 const Nickname = styled.span`
@@ -74,10 +93,11 @@ const Nickname = styled.span`
 
 const SeniorInfo = styled.div`
   display: flex;
+  flex-direction: row;
   gap: 0.4rem;
-  align-items: center;
 
-  margin-top: 0.8rem;
+  width: 18rem;
+  margin-top: 0.3rem;
 `;
 
 const Company = styled.p<CompanyProps>`
@@ -86,7 +106,6 @@ const Company = styled.p<CompanyProps>`
   justify-content: center;
   align-items: center;
 
-  height: 2.5rem;
   padding: 0.4rem 0.6rem;
   border-radius: 6px;
 
@@ -120,7 +139,6 @@ const Company = styled.p<CompanyProps>`
 
 const Field = styled.p`
   display: flex;
-  gap: 1rem;
   justify-content: center;
   align-items: center;
 
@@ -135,30 +153,20 @@ const Field = styled.p`
 
 const SeniorJob = styled.div`
   display: flex;
-  gap: 1rem;
+  flex-flow: row wrap;
+  gap: 0.2rem;
   align-items: center;
 
-  width: 19.2rem;
-  margin-top: 0.5rem;
-`;
-const Position = styled.p`
-  ${({ theme }) => theme.fonts.Body1_M_14}
+  width: 21rem;
+
+  ${({ theme }) => theme.fonts.Body1_M_14};
   color: ${({ theme }) => theme.colors.grayScaleDG};
 `;
 
 const Divider = styled.div`
   width: 0.1rem;
   height: 1.4rem;
+  margin: 0.5rem;
 
   background: ${({ theme }) => theme.colors.grayScaleLG2};
-`;
-
-const DetailPosition = styled.p`
-  color: ${({ theme }) => theme.colors.grayScaleDG};
-  ${({ theme }) => theme.fonts.Body1_M_14};
-`;
-
-const Level = styled.p`
-  ${({ theme }) => theme.fonts.Body1_M_14};
-  color: ${({ theme }) => theme.colors.grayScaleDG};
 `;

--- a/src/pages/seniorProfile/components/Example.tsx
+++ b/src/pages/seniorProfile/components/Example.tsx
@@ -1,9 +1,9 @@
+import styled from '@emotion/styled';
 import { ArrowLeftIc } from '@assets/svgs';
 import LogoIc from '@assets/svgs/ic_main_logo.svg?react';
 import { FullBtn } from '@components/commons/FullButton';
 import { Header } from '@components/commons/Header';
 import SeniorCard from '@components/commons/seniorCard/SeniorCard';
-import styled from '@emotion/styled';
 import PreView from '@pages/seniorProfile/components/preView';
 import { SENIOR_PROFILE_STEPS } from '@pages/seniorProfile/constants';
 import { useSeniorCardQuery } from '@pages/seniorProfile/hooks/useSeniorCardQuery';
@@ -13,11 +13,8 @@ import { useState } from 'react';
 const Example = ({ setStep }: { setStep: React.Dispatch<React.SetStateAction<number>> }) => {
   const [seniorId, setSeniorId] = useState(0);
   const { data: data1 } = useSeniorCardQuery('24');
-  // const { data: data1, error: error1, isLoading: isLoading1 } = useSeniorCardQuery('24');
   const { data: data2 } = useSeniorCardQuery('25');
-  // const { data: data2, error: error2, isLoading: isLoading2 } = useSeniorCardQuery('25');
   const { data: data3 } = useSeniorCardQuery('26');
-  // const { data: data3, error: error3, isLoading: isLoading3 } = useSeniorCardQuery('26');
 
   const dummayData = [data1, data2, data3];
 
@@ -37,9 +34,9 @@ const Example = ({ setStep }: { setStep: React.Dispatch<React.SetStateAction<num
           <Wrapper>
             <LogoIcon />
             <Meta>{SENIOR_PROFILE_STEPS[1].meta}</Meta>
-            <CardContainer>
+            <SeniorListWrapper>
               {dummayData.map((d, idx) => (
-                <div onClick={() => handleCardClick(idx + 24)}>
+                <CardWrapper key={idx} onClick={() => handleCardClick(idx + 24)}>
                   <SeniorCard
                     nickname={d?.nickname + ''}
                     company={d?.company + ''}
@@ -48,10 +45,11 @@ const Example = ({ setStep }: { setStep: React.Dispatch<React.SetStateAction<num
                     detailPosition={d?.detailPosition + ''}
                     level={d?.level + ''}
                     variant="secondary"
+                    image="/image"
                   />
-                </div>
+                </CardWrapper>
               ))}
-            </CardContainer>
+            </SeniorListWrapper>
           </Wrapper>
           <FullBtn
             text="다음으로"
@@ -80,10 +78,21 @@ const LogoIcon = styled(LogoIc)`
   margin-bottom: 2.2rem;
 `;
 
-const CardContainer = styled.section`
+const SeniorListWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  align-items: center;
 
-  padding: 3rem 0 0;
+  width: 100%;
+  height: 100%;
+  margin-top: 3.4rem;
+`;
+
+const CardWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  width: 100%;
 `;


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #186 

## ✅ Done Task
  - [x] seniorProfile 페이지 카드리스트 레이아웃 조정
  - [ ] Example div 빈 태그에 스타일코드 추가 

## ☀️ New-insight
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->

## 💎 PR Point
✅ SeniorCard를 사용하는 구조가 달랐습니다. 
- 최종 구조
- : JuniorPromisePage
` <SeniorListWrapper>
          {seniorList?.map((list) => (
            <SeniorCard
              key={list.seniorId}
              nickname={list.nickname}
              company={list.company}
              image={list.image}
              field={list.field}
              position={list.position}
              detailPosition={list.detailPosition}
              level={list.level}
              variant="secondary"
            />
          ))}
        </SeniorListWrapper>`


-: ExamplePage
`<SeniorListWrapper>
              {dummayData.map((d, idx) => (
                <CardWrapper key={idx} onClick={() => handleCardClick(idx + 24)}>
                  <SeniorCard
                    nickname={d?.nickname + ''}
                    company={d?.company + ''}
                    field={d?.field + ''}
                    position={d?.position + ''}
                    detailPosition={d?.detailPosition + ''}
                    level={d?.level + ''}
                    variant="secondary"
                    image="/image"
                  />
                </CardWrapper>
              ))}
            </SeniorListWrapper>`

## 📸 Screenshot
<img width="385" alt="스크린샷 2024-07-19 오후 4 16 11" src="https://github.com/user-attachments/assets/d294cde3-a140-480d-8108-8e73cc1b9075">
<img width="386" alt="스크린샷 2024-07-19 오후 4 16 26" src="https://github.com/user-attachments/assets/be495cd0-8911-4ec9-a68f-a0c92296fb71">
