### PR TITLE
[Fix] 구글 소셜 로그인 라이브러리 없이 구현 및 회원가입 플로우 문제 해결

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,11 +1,11 @@
 {
-     "printWidth": 120,
-     "tabWidth": 2,
-     "semi": true,
-     "singleQuote": true,
-     "trailingComma": "all",
-     "requirePragma": false,
-     "arrowParens": "always",
-     "bracketSameLine": true,
-     "endOfLine": "auto"
+  "printWidth": 120,
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "requirePragma": false,
+  "arrowParens": "always",
+  "bracketSameLine": true,
+  "endOfLine": "auto"
 }

--- a/package.json
+++ b/package.json
@@ -13,11 +13,9 @@
   "dependencies": {
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",
-    "@react-oauth/google": "^0.12.1",
     "@tanstack/react-query": "^5.48.0",
     "axios": "^1.7.2",
     "emotion-reset": "^3.0.1",
-    "jwt-decode": "^4.0.0",
     "lottie-web": "^5.12.2",
     "moment": "^2.30.1",
     "prettier": "^3.3.2",

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -50,7 +50,7 @@ const router = createBrowserRouter([
         element: <SignupPage />,
       },
       {
-        path: 'login/oauth2/code/google',
+        path: 'auth/google',
         element: <LoginCallback />,
       },
       {

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -22,6 +22,7 @@ import Layout from '@pages/onboarding/components/Layout';
 import JoinPage from '@pages/join/JoinPage';
 import ErrorPage from '@pages/errorPage/ErrorPage';
 import StepComplete from '@pages/onboarding/components/juniorOnboarding/StepComplete';
+import LoginCallback from '@pages/login/LoginCallback';
 
 const router = createBrowserRouter([
   {
@@ -47,6 +48,10 @@ const router = createBrowserRouter([
       {
         path: 'signup',
         element: <SignupPage />,
+      },
+      {
+        path: 'login/oauth2/code/google',
+        element: <LoginCallback />,
       },
       {
         path: 'seniorOnboarding',

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,17 +1,13 @@
-import { GoogleOAuthProvider } from '@react-oauth/google';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import ReactDOM from 'react-dom/client';
 import Router from './Router.tsx';
 
 const queryClient = new QueryClient();
-const clientId = import.meta.env.VITE_APP_GOOGLE_CLIENT_ID + '';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <>
-    <GoogleOAuthProvider clientId={clientId}>
-      <QueryClientProvider client={queryClient}>
-        <Router />
-      </QueryClientProvider>
-    </GoogleOAuthProvider>
+    <QueryClientProvider client={queryClient}>
+      <Router />
+    </QueryClientProvider>
   </>,
 );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,5 @@
 import { GoogleOAuthProvider } from '@react-oauth/google';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import React from 'react';
 import ReactDOM from 'react-dom/client';
 import Router from './Router.tsx';
 
@@ -8,11 +7,11 @@ const queryClient = new QueryClient();
 const clientId = import.meta.env.VITE_APP_GOOGLE_CLIENT_ID + '';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
+  <>
     <GoogleOAuthProvider clientId={clientId}>
       <QueryClientProvider client={queryClient}>
         <Router />
       </QueryClientProvider>
     </GoogleOAuthProvider>
-  </React.StrictMode>,
+  </>,
 );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,5 +9,5 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
     <QueryClientProvider client={queryClient}>
       <Router />
     </QueryClientProvider>
-  </>,
+  </>
 );

--- a/src/pages/join/JoinPage.tsx
+++ b/src/pages/join/JoinPage.tsx
@@ -3,31 +3,9 @@ import styled from '@emotion/styled';
 import JoinButton from '@pages/join/components/Button';
 import Welcome from '@pages/join/components/Welcome';
 import useGoogleLoginHook from '@pages/login/hooks/useLoginQuery';
-import { useNavigate } from 'react-router-dom';
 
 const JoinPage = () => {
   const { login } = useGoogleLoginHook({ variant: 'login' });
-  const navigate = useNavigate();
-  const handleSenior = () => {
-    localStorage.setItem('role', 'SENIOR');
-    localStorage.setItem(
-      'accessToken',
-      'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJpYXQiOjE3MjEzODYwOTgsImV4cCI6MTc4MTg2NjA5OCwibWVtYmVySWQiOjF9.akUlaIos348cj7o57GMOjd5dWp2LE0R0Vk3IoZaP3X73dbGRkMkTCDGPMcTh_5JJUVyHtk6qO1tmLkMSYoViig',
-    );
-  };
-
-  const handleJunior = () => {
-    localStorage.setItem('role', 'JUNIOR');
-    localStorage.setItem(
-      'accessToken',
-      'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJpYXQiOjE3MjEzODYyNTgsImV4cCI6MTc4MTg2NjI1OCwibWVtYmVySWQiOjJ9.YTtOIDAgg-qZhuiwA4ZxXeyKBpV6UU1XsSAlxNy1sr_2P1Hl7iL94b0EoR1zxuJfUlcgBH8oY0UZ4kj1VzNGyg',
-    );
-  };
-
-  const handleNext = () => {
-    const role = localStorage.getItem('role');
-    role === 'SENIOR' ? navigate('/') : role === 'JUNIOR' && navigate('/juniorPromise');
-  };
 
   return (
     <>
@@ -51,44 +29,11 @@ const JoinPage = () => {
           </SignupContent>
         </SignupContainer>
       </Wrapper>
-      <SeniorBtn onClick={handleSenior} />
-      <JuniorBtn onClick={handleJunior} />
-      <DemoNextBtn onClick={handleNext} />
     </>
   );
 };
 
 export default JoinPage;
-
-const SeniorBtn = styled.div`
-  position: absolute;
-  bottom: 50%;
-  left: 0;
-  z-index: 10;
-
-  width: 5rem;
-  height: 5rem;
-`;
-
-const JuniorBtn = styled.div`
-  position: absolute;
-  right: 0;
-  bottom: 50%;
-  z-index: 10;
-
-  width: 5rem;
-  height: 5rem;
-`;
-
-export const DemoNextBtn = styled.div`
-  position: absolute;
-  right: 35%;
-  bottom: 50%;
-  z-index: 10;
-
-  width: 10rem;
-  height: 5rem;
-`;
 
 const Wrapper = styled.div`
   display: flex;

--- a/src/pages/join/JoinPage.tsx
+++ b/src/pages/join/JoinPage.tsx
@@ -2,11 +2,9 @@ import { BigMainLogoIc, OnboardingGradIc } from '@assets/svgs';
 import styled from '@emotion/styled';
 import JoinButton from '@pages/join/components/Button';
 import Welcome from '@pages/join/components/Welcome';
-import useGoogleLoginHook from '@pages/login/hooks/useLoginQuery';
+import googleLogin from '@pages/login/utils/googleLogin';
 
 const JoinPage = () => {
-  const { login } = useGoogleLoginHook({ variant: 'login' });
-
   return (
     <>
       <OnboardingGradIcon />
@@ -23,7 +21,7 @@ const JoinPage = () => {
         <JoinButton />
         <SignupContainer>
           <QuestionText>이미 아이디가 있으신가요?</QuestionText>
-          <SignupContent onClick={() => login()}>
+          <SignupContent onClick={() => googleLogin()}>
             <SignupText>로그인 하기</SignupText>
             <Underline />
           </SignupContent>

--- a/src/pages/join/components/Welcome.tsx
+++ b/src/pages/join/components/Welcome.tsx
@@ -6,7 +6,6 @@ import WelcomeJson from '@assets/lottie/welcome.json';
 const Welcome = () => {
   const likecontainer = useRef<HTMLDivElement>(null!);
   useEffect(() => {
-    console.log({ WelcomeJson });
     if (likecontainer.current !== null) {
       const animation = Lottie.loadAnimation({
         container: likecontainer.current,

--- a/src/pages/juniorPromise/JuniorPromisePage.tsx
+++ b/src/pages/juniorPromise/JuniorPromisePage.tsx
@@ -243,8 +243,10 @@ const SeniorListWrapper = styled.div`
 
 const Background = styled.div`
   position: relative;
-  height: 18.7rem;
+
   width: 100vw;
+  height: 18.7rem;
+
   background: linear-gradient(151deg, #cce7ff 17.85%, #b8b1ff 163.57%);
 `;
 

--- a/src/pages/login/LoginCallback.tsx
+++ b/src/pages/login/LoginCallback.tsx
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+import useGoogleLoginHook from './hooks/useLoginQuery';
+
+const LoginCallback = () => {
+  const role = localStorage.getItem('role');
+  const { mutation } = useGoogleLoginHook({ role: role || undefined });
+  const params = new URLSearchParams(window.location.search);
+  const code = params.get('code');
+  console.log('리디렉왔어용~ 코드는 : ', code);
+
+  useEffect(() => {
+    if (code) mutation.mutate(code);
+  }, [code]);
+
+  return null;
+};
+
+export default LoginCallback;

--- a/src/pages/login/LoginCallback.tsx
+++ b/src/pages/login/LoginCallback.tsx
@@ -1,15 +1,15 @@
 import { useEffect } from 'react';
-import useGoogleLoginHook from './hooks/useLoginQuery';
+import useGoogleLoginMutation from './hooks/useGoogleLoginMutation';
 
 const LoginCallback = () => {
   const role = localStorage.getItem('role');
-  const { mutation } = useGoogleLoginHook({ role: role || undefined });
+  const { mutate: login } = useGoogleLoginMutation({ role: role || undefined });
   const params = new URLSearchParams(window.location.search);
   const code = params.get('code');
   console.log('리디렉왔어용~ 코드는 : ', code);
 
   useEffect(() => {
-    if (code) mutation.mutate(code);
+    if (code) login(code);
   }, [code]);
 
   return null;

--- a/src/pages/login/LoginCallback.tsx
+++ b/src/pages/login/LoginCallback.tsx
@@ -2,11 +2,10 @@ import { useEffect } from 'react';
 import useGoogleLoginMutation from './hooks/useGoogleLoginMutation';
 
 const LoginCallback = () => {
-  const role = localStorage.getItem('role');
-  const { mutate: login } = useGoogleLoginMutation({ role: role || undefined });
   const params = new URLSearchParams(window.location.search);
+  const role = params.get('state');
   const code = params.get('code');
-  console.log('리디렉왔어용~ 코드는 : ', code);
+  const { mutate: login } = useGoogleLoginMutation({ role: role || undefined });
 
   useEffect(() => {
     if (code) login(code);

--- a/src/pages/login/SignupPage.tsx
+++ b/src/pages/login/SignupPage.tsx
@@ -2,17 +2,11 @@ import { GoogleLogoIc, OnboardingBackgroundHBIc, OnboardingBackgroundSBIc } from
 import styled from '@emotion/styled';
 import theme from '@styles/theme';
 import useGoogleLoginHook from './hooks/useLoginQuery';
-import { DemoNextBtn } from '@pages/join/JoinPage';
-import { useNavigate } from 'react-router-dom';
 
 const SignupPage = () => {
   const role = localStorage.getItem('role');
   const { login } = useGoogleLoginHook({});
-  const navigate = useNavigate();
 
-  const handleNextBtn = () => {
-    role === 'SENIOR' ? navigate('/seniorOnboarding') : role === 'JUNIOR' && navigate('/juniorOnboarding');
-  };
   return (
     <>
       {role === 'SENIOR' ? <OnboardingBackgroundSBIcon /> : <OnboardingBackgroundHBIcon />}
@@ -20,7 +14,6 @@ const SignupPage = () => {
         <GoogleLogoIcon />
         <Text>구글로 시작하기</Text>
       </BtnContainer>
-      <DemoNextBtn onClick={handleNextBtn} />
     </>
   );
 };

--- a/src/pages/login/SignupPage.tsx
+++ b/src/pages/login/SignupPage.tsx
@@ -1,18 +1,17 @@
 import { GoogleLogoIc, OnboardingBackgroundHBIc, OnboardingBackgroundSBIc } from '@assets/svgs';
 import styled from '@emotion/styled';
 import theme from '@styles/theme';
-import useGoogleLoginHook from './hooks/useLoginQuery';
 import { useLocation } from 'react-router-dom';
+import googleLogin from './utils/googleLogin';
 
 const SignupPage = () => {
   const role = useLocation().state.role;
   localStorage.setItem('role', role);
-  const { login } = useGoogleLoginHook({ role: role || undefined });
 
   return (
     <>
       {role === 'SENIOR' ? <OnboardingBackgroundSBIcon /> : <OnboardingBackgroundHBIcon />}
-      <BtnContainer onClick={() => login()}>
+      <BtnContainer onClick={() => googleLogin()}>
         <GoogleLogoIcon />
         <Text>구글로 시작하기</Text>
       </BtnContainer>

--- a/src/pages/login/SignupPage.tsx
+++ b/src/pages/login/SignupPage.tsx
@@ -2,10 +2,12 @@ import { GoogleLogoIc, OnboardingBackgroundHBIc, OnboardingBackgroundSBIc } from
 import styled from '@emotion/styled';
 import theme from '@styles/theme';
 import useGoogleLoginHook from './hooks/useLoginQuery';
+import { useLocation } from 'react-router-dom';
 
 const SignupPage = () => {
-  const role = localStorage.getItem('role');
-  const { login } = useGoogleLoginHook({});
+  const role = useLocation().state.role;
+  localStorage.setItem('role', role);
+  const { login } = useGoogleLoginHook({ role: role || undefined });
 
   return (
     <>

--- a/src/pages/login/SignupPage.tsx
+++ b/src/pages/login/SignupPage.tsx
@@ -6,12 +6,11 @@ import googleLogin from './utils/googleLogin';
 
 const SignupPage = () => {
   const role = useLocation().state.role;
-  localStorage.setItem('role', role);
 
   return (
     <>
       {role === 'SENIOR' ? <OnboardingBackgroundSBIcon /> : <OnboardingBackgroundHBIcon />}
-      <BtnContainer onClick={() => googleLogin()}>
+      <BtnContainer onClick={() => googleLogin(role)}>
         <GoogleLogoIcon />
         <Text>구글로 시작하기</Text>
       </BtnContainer>

--- a/src/pages/login/apis/loginAxios.ts
+++ b/src/pages/login/apis/loginAxios.ts
@@ -5,7 +5,7 @@ export const loginAxios = (authorizationCode: string) => {
   return axios.post(
     '/v1/auth/login',
     {
-      redirectUri: 'http://localhost:5173/auth/google',
+      redirectUri: import.meta.env.VITE_APP_GOOGLE_AUTH_REDIRECT_URI,
       socialType: 'GOOGLE',
     },
     {

--- a/src/pages/login/apis/loginAxios.ts
+++ b/src/pages/login/apis/loginAxios.ts
@@ -1,10 +1,11 @@
 import { axios } from '@utils/apis';
 
-export const loginAxios = (authorizationCode: string | undefined) => {
+export const loginAxios = (authorizationCode: string) => {
+  console.log('🚀 login post 쐈어용 ~ ');
   return axios.post(
     '/v1/auth/login',
     {
-      redirectUri: '',
+      redirectUri: 'http://localhost:5173/login/oauth2/code/google',
       socialType: 'GOOGLE',
     },
     {
@@ -13,4 +14,17 @@ export const loginAxios = (authorizationCode: string | undefined) => {
       },
     },
   );
+  // console.log(response);
+  // return axios.post(
+  //   '/v1/auth/login',
+  //   {
+  //     redirectUri: 'http://localhost:5173/login/oauth2/code/google',
+  //     socialType: 'GOOGLE',
+  //   },
+  //   {
+  //     params: {
+  //       authorizationCode,
+  //     },
+  //   },
+  // );
 };

--- a/src/pages/login/apis/loginAxios.ts
+++ b/src/pages/login/apis/loginAxios.ts
@@ -5,7 +5,7 @@ export const loginAxios = (authorizationCode: string) => {
   return axios.post(
     '/v1/auth/login',
     {
-      redirectUri: 'http://localhost:5173/login/oauth2/code/google',
+      redirectUri: 'http://localhost:5173/auth/google',
       socialType: 'GOOGLE',
     },
     {
@@ -14,17 +14,4 @@ export const loginAxios = (authorizationCode: string) => {
       },
     },
   );
-  // console.log(response);
-  // return axios.post(
-  //   '/v1/auth/login',
-  //   {
-  //     redirectUri: 'http://localhost:5173/login/oauth2/code/google',
-  //     socialType: 'GOOGLE',
-  //   },
-  //   {
-  //     params: {
-  //       authorizationCode,
-  //     },
-  //   },
-  // );
 };

--- a/src/pages/login/apis/loginAxios.ts
+++ b/src/pages/login/apis/loginAxios.ts
@@ -1,7 +1,6 @@
 import { axios } from '@utils/apis';
 
 export const loginAxios = (authorizationCode: string) => {
-  console.log('🚀 login post 쐈어용 ~ ');
   return axios.post(
     '/v1/auth/login',
     {

--- a/src/pages/login/hooks/useGoogleLoginMutation.ts
+++ b/src/pages/login/hooks/useGoogleLoginMutation.ts
@@ -5,7 +5,7 @@ import { useNavigate } from 'react-router-dom';
 interface useGoogleLoginPropType {
   role?: string;
 }
-const useGoogleLoginMutation = ({ role = 'SENIOR' }: useGoogleLoginPropType) => {
+const useGoogleLoginMutation = ({ role }: useGoogleLoginPropType) => {
   const navigate = useNavigate();
   return useMutation({
     mutationFn: (authorizationCode: string) => loginAxios(authorizationCode),
@@ -18,10 +18,13 @@ const useGoogleLoginMutation = ({ role = 'SENIOR' }: useGoogleLoginPropType) => 
         console.log('🍀로그인');
         localStorage.setItem('role', responseRole);
         navigate('/');
-      } else {
+      } else if (role) {
         // 회원가입
         console.log('🥰회원가입');
         navigate(role === 'SENIOR' ? '/seniorOnboarding' : '/juniorOnboarding');
+      } else {
+        // 로그인인데, role 정보를 서버에서 받지 못한 상황
+        console.error('🔴 로그인 과정에서 Role 정보를 서버에서 받지 못했어요.');
       }
     },
     onError: (error) => {

--- a/src/pages/login/hooks/useGoogleLoginMutation.ts
+++ b/src/pages/login/hooks/useGoogleLoginMutation.ts
@@ -15,12 +15,10 @@ const useGoogleLoginMutation = ({ role }: useGoogleLoginPropType) => {
       const responseRole = data.data.data.role;
       if (responseRole) {
         // 로그인 (이미 가입된 회원)
-        console.log('🍀로그인');
         localStorage.setItem('role', responseRole);
         navigate('/');
       } else if (role) {
         // 회원가입
-        console.log('🥰회원가입');
         navigate(role === 'SENIOR' ? '/seniorOnboarding' : '/juniorOnboarding');
       } else {
         // 로그인인데, role 정보를 서버에서 받지 못한 상황

--- a/src/pages/login/hooks/useGoogleLoginMutation.ts
+++ b/src/pages/login/hooks/useGoogleLoginMutation.ts
@@ -6,9 +6,9 @@ interface useGoogleLoginPropType {
   role?: string;
   variant?: 'signup' | 'login';
 }
-const useGoogleLoginHook = ({ role = 'SENIOR', variant = 'signup' }: useGoogleLoginPropType) => {
+const useGoogleLoginMutation = ({ role = 'SENIOR', variant = 'signup' }: useGoogleLoginPropType) => {
   const navigate = useNavigate();
-  const mutation = useMutation({
+  return useMutation({
     mutationFn: (authorizationCode: string) => loginAxios(authorizationCode),
     onSuccess: (data) => {
       console.log('🟢성공하셨어용~🟢');
@@ -30,11 +30,6 @@ const useGoogleLoginHook = ({ role = 'SENIOR', variant = 'signup' }: useGoogleLo
       console.error('🔴login post Error: ', error);
     },
   });
-
-  const login = () => {
-    window.location.href = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${import.meta.env.VITE_APP_GOOGLE_CLIENT_ID}&redirect_uri=${import.meta.env.VITE_APP_GOOGLE_AUTH_REDIRECT_URI}&response_type=code&scope=email`;
-  };
-  return { login, mutation };
 };
 
-export default useGoogleLoginHook;
+export default useGoogleLoginMutation;

--- a/src/pages/login/hooks/useGoogleLoginMutation.ts
+++ b/src/pages/login/hooks/useGoogleLoginMutation.ts
@@ -4,26 +4,24 @@ import { useNavigate } from 'react-router-dom';
 
 interface useGoogleLoginPropType {
   role?: string;
-  variant?: 'signup' | 'login';
 }
-const useGoogleLoginMutation = ({ role = 'SENIOR', variant = 'signup' }: useGoogleLoginPropType) => {
+const useGoogleLoginMutation = ({ role = 'SENIOR' }: useGoogleLoginPropType) => {
   const navigate = useNavigate();
   return useMutation({
     mutationFn: (authorizationCode: string) => loginAxios(authorizationCode),
     onSuccess: (data) => {
-      console.log('🟢성공하셨어용~🟢');
       localStorage.setItem('accessToken', data.data.data.accessToken);
+
       const responseRole = data.data.data.role;
       if (responseRole) {
-        console.log('💕');
+        // 로그인 (이미 가입된 회원)
+        console.log('🍀로그인');
         localStorage.setItem('role', responseRole);
         navigate('/');
-      } else if (variant === 'login') {
-        console.log('🟡');
-        alert('가입되지 않은 회원입니다.');
       } else {
-        console.log('🔴', role);
-        role === 'SENIOR' ? navigate('/seniorOnboarding') : role === 'JUNIOR' && navigate('/juniorOnboarding');
+        // 회원가입
+        console.log('🥰회원가입');
+        navigate(role === 'SENIOR' ? '/seniorOnboarding' : '/juniorOnboarding');
       }
     },
     onError: (error) => {

--- a/src/pages/login/hooks/useGoogleLoginMutation.ts
+++ b/src/pages/login/hooks/useGoogleLoginMutation.ts
@@ -16,7 +16,7 @@ const useGoogleLoginMutation = ({ role }: useGoogleLoginPropType) => {
       if (responseRole) {
         // 로그인 (이미 가입된 회원)
         localStorage.setItem('role', responseRole);
-        navigate('/');
+        navigate(responseRole === 'SENIOR' ? '/' : '/juniorPromise');
       } else if (role) {
         // 회원가입
         navigate(role === 'SENIOR' ? '/seniorOnboarding' : '/juniorOnboarding');

--- a/src/pages/login/hooks/useLoginQuery.ts
+++ b/src/pages/login/hooks/useLoginQuery.ts
@@ -31,21 +31,6 @@ const useGoogleLoginHook = ({ role = 'SENIOR', variant = 'signup' }: useGoogleLo
     },
   });
 
-  //   const login = useGoogleLogin({
-  //     onSuccess: (response) => {
-  //       const authorizationCode = response.code;
-  //       mutation.mutate(authorizationCode);
-  //     },
-  //     onError: (error) => {
-  //       console.log('Login Failed:', error);
-  //       navigate('/error');
-  //     },
-  //     flow: 'auth-code',
-  //     redirect_uri: 'http://localhost:5173/login/oauth2/code/google',
-  //   });
-
-  //   return { login, mutation };
-  // };
   const login = () => {
     window.location.href = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${import.meta.env.VITE_APP_GOOGLE_CLIENT_ID}&redirect_uri=${import.meta.env.VITE_APP_GOOGLE_AUTH_REDIRECT_URI}&response_type=code&scope=email`;
   };

--- a/src/pages/login/hooks/useLoginQuery.ts
+++ b/src/pages/login/hooks/useLoginQuery.ts
@@ -1,48 +1,54 @@
-import { useGoogleLogin } from '@react-oauth/google';
 import { useMutation } from '@tanstack/react-query';
 import { loginAxios } from '../apis/loginAxios';
 import { useNavigate } from 'react-router-dom';
 
 interface useGoogleLoginPropType {
   role?: string;
-  variant?: 'signup' | 'login'
+  variant?: 'signup' | 'login';
 }
-const useGoogleLoginHook = ({ role, variant = 'signup' }: useGoogleLoginPropType) => {
+const useGoogleLoginHook = ({ role = 'SENIOR', variant = 'signup' }: useGoogleLoginPropType) => {
   const navigate = useNavigate();
   const mutation = useMutation({
     mutationFn: (authorizationCode: string) => loginAxios(authorizationCode),
     onSuccess: (data) => {
+      console.log('🟢성공하셨어용~🟢');
       localStorage.setItem('accessToken', data.data.data.accessToken);
       const responseRole = data.data.data.role;
       if (responseRole) {
+        console.log('💕');
         localStorage.setItem('role', responseRole);
         navigate('/');
       } else if (variant === 'login') {
+        console.log('🟡');
         alert('가입되지 않은 회원입니다.');
       } else {
-        role === 'SENIOR' ? navigate('/seniorOnboarding')
-          : role === 'JUNIOR' && navigate('/juniorOnboarding');
+        console.log('🔴', role);
+        role === 'SENIOR' ? navigate('/seniorOnboarding') : role === 'JUNIOR' && navigate('/juniorOnboarding');
       }
     },
     onError: (error) => {
-      console.error('login post Error: ', error);
-      navigate('/error');
+      console.error('🔴login post Error: ', error);
     },
   });
 
-  const login = useGoogleLogin({
-    onSuccess: () => {
-      // const authorizationCode = response.code;
-      // mutation.mutate(authorizationCode);
-    },
-    onError: (error) => {
-      console.log('Login Failed:', error);
-      navigate('/error');
-    },
-    flow: 'auth-code',
-    redirect_uri: import.meta.env.VITE_APP_REDIRECT_URI
-  });
+  //   const login = useGoogleLogin({
+  //     onSuccess: (response) => {
+  //       const authorizationCode = response.code;
+  //       mutation.mutate(authorizationCode);
+  //     },
+  //     onError: (error) => {
+  //       console.log('Login Failed:', error);
+  //       navigate('/error');
+  //     },
+  //     flow: 'auth-code',
+  //     redirect_uri: 'http://localhost:5173/login/oauth2/code/google',
+  //   });
 
+  //   return { login, mutation };
+  // };
+  const login = () => {
+    window.location.href = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${import.meta.env.VITE_APP_GOOGLE_CLIENT_ID}&redirect_uri=${import.meta.env.VITE_APP_GOOGLE_AUTH_REDIRECT_URI}&response_type=code&scope=email`;
+  };
   return { login, mutation };
 };
 

--- a/src/pages/login/utils/googleLogin.ts
+++ b/src/pages/login/utils/googleLogin.ts
@@ -1,0 +1,5 @@
+const googleLogin = () => {
+  window.location.href = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${import.meta.env.VITE_APP_GOOGLE_CLIENT_ID}&redirect_uri=${import.meta.env.VITE_APP_GOOGLE_AUTH_REDIRECT_URI}&response_type=code&scope=email`;
+};
+
+export default googleLogin;

--- a/src/pages/login/utils/googleLogin.ts
+++ b/src/pages/login/utils/googleLogin.ts
@@ -1,5 +1,5 @@
-const googleLogin = () => {
-  window.location.href = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${import.meta.env.VITE_APP_GOOGLE_CLIENT_ID}&redirect_uri=${import.meta.env.VITE_APP_GOOGLE_AUTH_REDIRECT_URI}&response_type=code&scope=email`;
+const googleLogin = (role?: 'SENIOR' | 'JUNIOR') => {
+  window.location.href = `https://accounts.google.com/o/oauth2/v2/auth?${role ? `state=${role}&` : ''}client_id=${import.meta.env.VITE_APP_GOOGLE_CLIENT_ID}&redirect_uri=${import.meta.env.VITE_APP_GOOGLE_AUTH_REDIRECT_URI}&response_type=code&scope=email`;
 };
 
 export default googleLogin;

--- a/src/pages/onboarding/apis/joinAxios.ts
+++ b/src/pages/onboarding/apis/joinAxios.ts
@@ -4,10 +4,8 @@ import { JoinPropType, JoinRequesetType } from '../type';
 export const joinAxios = (requestBody: JoinPropType) => {
   const request: JoinRequesetType = {
     ...requestBody,
-    image: '',
+    image: 'https://example.com/business-card.jpg',
     isSubscribed: requestBody.isSubscribed[4],
   };
-  return authAxios.patch('/v1/auth/join', {
-    request,
-  });
+  return authAxios.patch('/v1/auth/join', request);
 };

--- a/src/pages/onboarding/components/Layout.tsx
+++ b/src/pages/onboarding/components/Layout.tsx
@@ -18,7 +18,7 @@ const Layout = ({ userRole }: { userRole: 'SENIOR' | 'JUNIOR' }) => {
   const GROUP_STEP = convertToGroupStep(userRole, step);
 
   const [data, setData] = useState<JoinPropType>({
-    userType: userRole === 'SENIOR' ? 1 : 2,
+    role: userRole,
     isSubscribed: Array(5).fill(false),
     nickname: '',
     image: '',

--- a/src/pages/onboarding/hooks/useJoinQuery.ts
+++ b/src/pages/onboarding/hooks/useJoinQuery.ts
@@ -9,7 +9,7 @@ const useJoinQuery = () => {
       localStorage.setItem('role', data.data.role);
     },
     onError: (error) => {
-      console.log('join patch Error: ', error);
+      console.log('🔴 join patch Error: ', error);
     },
   });
 

--- a/src/pages/onboarding/hooks/useJoinQuery.ts
+++ b/src/pages/onboarding/hooks/useJoinQuery.ts
@@ -6,7 +6,7 @@ const useJoinQuery = () => {
   const mutation = useMutation({
     mutationFn: (requestBody: JoinPropType) => joinAxios(requestBody),
     onSuccess: (data) => {
-      localStorage.setItem('role', data.data.userType);
+      localStorage.setItem('role', data.data.role);
     },
     onError: (error) => {
       console.log('join patch Error: ', error);

--- a/src/pages/onboarding/type.ts
+++ b/src/pages/onboarding/type.ts
@@ -9,7 +9,7 @@ export interface BizInfoType {
 }
 
 export interface JoinPropType {
-  userType: number;
+  role: 'SENIOR' | 'JUNIOR';
   isSubscribed: boolean[];
   nickname: string;
   image: string;
@@ -24,7 +24,7 @@ export interface JoinPropType {
   level?: string;
 }
 export interface JoinRequesetType {
-  userType: number;
+  role: 'SENIOR' | 'JUNIOR';
   isSubscribed: boolean;
   nickname: string;
   image: string;

--- a/src/pages/promiseList/PromiseListPage.tsx
+++ b/src/pages/promiseList/PromiseListPage.tsx
@@ -10,8 +10,7 @@ import Loading from '@components/commons/Loading';
 
 const PromiseListPage = () => {
   // 유저가 선배일 경우
-  // const userRole = localStorage.getItem('role') + '';
-  const userRole = 'JUNIOR';
+  const userRole = localStorage.getItem('role') + '';
 
   const { myNickname, pending, scheduled, past, isLoading } = useGetPromiseList();
 

--- a/src/utils/apis/index.ts
+++ b/src/utils/apis/index.ts
@@ -11,20 +11,18 @@ export const authAxios = _axios.default.create({
   baseURL: '/api',
   headers: {
     'Content-Type': 'application/json',
-    Authorization:
-      'Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJpYXQiOjE3MjEzODYyNTgsImV4cCI6MTc4MTg2NjI1OCwibWVtYmVySWQiOjJ9.YTtOIDAgg-qZhuiwA4ZxXeyKBpV6UU1XsSAlxNy1sr_2P1Hl7iL94b0EoR1zxuJfUlcgBH8oY0UZ4kj1VzNGyg',
   },
 });
 
-// authAxios.interceptors.request.use(
-//   (config) => {
-//     const accessToken = localStorage.getItem('accessToken');
-//     if (accessToken) {
-//       config.headers.Authorization = `Bearer ${accessToken}`;
-//     }
-//     return config;
-//   },
-//   (error) => {
-//     return Promise.reject(error);
-//   },
-// );
+authAxios.interceptors.request.use(
+  (config) => {
+    const accessToken = localStorage.getItem('accessToken');
+    if (accessToken) {
+      config.headers.Authorization = `Bearer ${accessToken}`;
+    }
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  },
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -575,11 +575,6 @@
   resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.1.1.tgz#1ec17e2edbec25c8306d424ecfbf13c7de1aaa31"
   integrity sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==
 
-"@react-oauth/google@^0.12.1":
-  version "0.12.1"
-  resolved "https://registry.yarnpkg.com/@react-oauth/google/-/google-0.12.1.tgz#b76432c3a525e9afe076f787d2ded003fcc1bee9"
-  integrity sha512-qagsy22t+7UdkYAiT5ZhfM4StXi9PPNvw0zuwNmabrWyMKddczMtBIOARflbaIj+wHiQjnMAsZmzsUYuXeyoSg==
-
 "@remix-run/router@1.17.0":
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.17.0.tgz#fbb0add487478ef42247d5942e7a5d8a2e20095f"
@@ -2577,11 +2572,6 @@ json5@^2.2.3:
     array.prototype.flat "^1.3.1"
     object.assign "^4.1.4"
     object.values "^1.1.6"
-
-jwt-decode@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-4.0.0.tgz#2270352425fd413785b2faf11f6e755c5151bd4b"
-  integrity sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==
 
 keyv@^4.5.3, keyv@^4.5.4:
   version "4.5.4"


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #213 

## ✅ Done Task
  - [x] 테스트용 코드 (매직버튼 구현) 삭제 
  - [x] 구글 소셜 로그인 Redirect URI env로 분리 
  - [x] 구글 소셜 로그인 버그 해결 (라이브러리 제거 후 로그인 로직 재구현) 
  - [x] 회원가입 API 통신 버그 해결 
  - [x] 로그인 - 온보딩 플로우 연결 및 선후배에 따른 분기 

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->
### 🤙🏻 라이브러리 없이 구글 소셜 로그인 구현하는 법 ! 

1️⃣ **`https://accounts.google.com/o/oauth2/v2/auth` 로 접속** 
- query string : 
  - client_id : 서버가 구글에서 발급받아서 전해준 CLIENT_ID
  - redirect_uri : 서버가 구글에 등록하고 알려준 REDIRECT_URI 
  - response_type : code (인가코드 받겠다는 뜻) 
  - scope : email (로그인 성공 시 구글에서 제공하는 회원 정보 중 이메일만 받겠다는 뜻) 

이 주소로 이동시키기 위해서 로그인/회원가입 버튼 클릭 시 아래의 login 함수를 클릭이벤트핸들러로 연결해줘요. 
```tsx
 const login = () => {
    window.location.href = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${import.meta.env.VITE_APP_GOOGLE_CLIENT_ID}&redirect_uri=${import.meta.env.VITE_APP_GOOGLE_AUTH_REDIRECT_URI}&response_type=code&scope=email`;
  };
```
> 여기서 VITE_APP_GOOGLE_CLIENT_ID, VITE_AP_GOOGLE_AUTH_REDIRECT_URI 는 서버가 구글 대시보드에 등록한 후, 저희에게 전달해주는 정보들입니다! 받아서 넣어주기만 하면 돼요 

<img width="1221" alt="image" src="https://github.com/user-attachments/assets/79a374b9-0d45-49a2-9f04-dcd94dfc4c85">

위 주소로 접속하면 우리가 흔히 아는 **구글로그인 화면**으로 이동돼요.
해당 화면에서 구글 로그인을 **성공**하면, 사용자 브라우저는 설정해둔 `redirect uri`로 **자동 리디렉**(페이지 이동) 되고,
그 리디렉된 주소 뒤에는 query string 형태로 구글이 **인가코드**를 붙여줘요. 


2️⃣ **리디렉 도착 장소 마련해주기** 
리디렉 URI로 도착하게되면, 그곳에서 저희는 구글이 붙여준 인가코드를 추출해야 해요. 
추출하려면 사용자가 도착하는 리디렉URI 위치에서 인가코드를 추출하는 로직을 짜줘야겠죠? 
현재 저희 리디렉 URI는 아래와 같아요. 
개발계 : `http://localhost:5173/auth/google`
운영계 : `https://seonyak.com/auth/google`

```
http://localhost:5173/auth/google?code=4/0AcvDMrAQ798ia_86dGjT5u57McyAzOIzW4oZYmpwlAROmcDnP7YA1yLeSgyLj_YGy4OdOw&scope=email%20openid%20https://www.googleapis.com/auth/userinfo.email&authuser=0&prompt=consent
```

그러면 뒤에 붙은 queryString과 앞에 붙은 도메인을 제거하고 
가운데에 path인 `/auth/google` 이 장소에서의 처리를 가능하게 하기 위해, 저희 쪽에서 route와 컴포넌트 하나를 만들어줍니다. 

> Router.tsx
```tsx
      {
        path: 'signup',
        element: <SignupPage />,
      },
      {
        path: 'auth/google', // 이렇게 ! 
        element: <LoginCallback />, // 이렇게 !
      },
```
이렇게 다른 일반 route들처럼, 리디렉 주소도 똑같이 추가해줘요. 
그리고 `LoginCallback`이라는 새로운 컴포넌트를 하나 만들어줬어요. 
이렇게 해주면 사용자가 구글 로그인에 성공하면 LoginCallback이라는 페이지에 도착하게 되겠죠? 


<br/>

3️⃣ **인가코드 추출하기** 

리디렉 후 도착 장소를 만들어주었으면 (LoginCallback) 
여기서 아까 말한 **인가코드 추출 로직**을 구현해주어야 해요. 

<img width="800" alt="image" src="https://github.com/user-attachments/assets/b87c7296-5c59-446d-b2fb-dd48b916597b">

이런 주소에 도착하게 되고, 여기서 우린 주소 뒤에 붙은 `code=어쩌구저쩌구` <- 이 어쩌구저쩌구를 추출해야 해요. 

추출하는 방법은 아래와 같아요. 
```tsx
const params = new URLSearchParams(window.location.search);
const code = params.get('code');
```

<br/>
 
4️⃣ **추출한 인가코드를 담아 API 통신해서 accessToken 받아오기!**
code에 인가코드가 성공적으로 담기면, 
이 인가코드를 담아서 서버에게 요청을 보내요. 
그럼 서버는 사용자의 로그인 세션을 유지시켜줄 `accessToken`을 응답으로 보내줍니다! 

<img width="500" alt="image" src="https://github.com/user-attachments/assets/c5bfd61d-bcfd-402e-bafc-989afc8ef0d2">

<img width="500" alt="image" src="https://github.com/user-attachments/assets/fde82cb8-3e91-4552-8396-fe8a922b0589">

해당 통신을 실행시켜주는 mutate 까지 성공적으로 호출해주면 LoginCallback의 역할은 끝이 납니다. 

> LoginCallback 전체 코드 
```tsx
const LoginCallback = () => {
  // 인가코드 추출 
  const params = new URLSearchParams(window.location.search);
  const code = params.get('code');

  // 구글로그인 API 통신 mutate 함수 가져오기 
  const { mutate: login } = useGoogleLoginMutation({ role: role || undefined });

  // 인가코드 담아서 mutate 함수 실행 
  useEffect(() => {
    if (code) login(code);  
  }, [code]);

  return null;
};
```

참고로 **이 컴포넌트가 null을 반환하는 이유**는
`LoginCallback`은 사용자에게 아무것도 보여주지 않고, **로그인 성공 후 메인페이지로 이동하기 전**까지 잠깐 들려서 **인가코드 추출 및 accessToken 발급만 실행**해주는 곳이기 때문에 아무런 UI를 보여주지 않기 위해 null을 반환합니다 


<br/>


5️⃣ **useGoogleLoginMutation은 어떻게 생겼는데요?**
```tsx
const useGoogleLoginMutation = ({ role }: useGoogleLoginPropType) => {
  const navigate = useNavigate();
  return useMutation({
    mutationFn: (authorizationCode: string) => loginAxios(authorizationCode),
    onSuccess: (data) => {
      localStorage.setItem('accessToken', data.data.data.accessToken);

      const responseRole = data.data.data.role;
      if (responseRole) {
        // 로그인 (이미 가입된 회원)
        localStorage.setItem('role', responseRole);
        navigate(responseRole === 'SENIOR' ? '/' : '/juniorPromise');
      } else if (role) {
        // 회원가입
        navigate(role === 'SENIOR' ? '/seniorOnboarding' : '/juniorOnboarding');
      } else {
        // 로그인인데, role 정보를 서버에서 받지 못한 상황
        console.error('🔴 로그인 과정에서 Role 정보를 서버에서 받지 못했어요.');
      }
    },
    onError: (error) => {
      console.error('🔴login post Error: ', error);
    },
  });
};
```
이렇게 생겼는데요! 
코드를 간단히 설명하면 
1.  mutate 함수 : `loginAxios` 통신 함수에 인가코드를 담아서 실행 
2. 통신 성공 시, 받아온 accessToken을 localStorage에 저장 
3. 서버에게 응답 받은 role이 있다면 (**이미 가입된 회원**이라면) 
-> localStorage에 사용자 role을 저장하고 
-> 선배면 선배 페이지로, 후배면 후배 페이지로 navigate 
4. 서버에게 응답 받은 role이 없는데, join페이지에서 넘어온 role 값은 있다면? (**비가입 회원**이라면)
-> 선배면 선배 온보딩으로, 후배면 후배 온보딩으로 navigate (회원가입 플로우 시작) 
5. 서버에게 응답 받은 role도 없고, join페이지에서 넘어온 role도 없다면? 
-> 회원가입이 아닌 로그인(3번) 플로우인데, 서버가 정상적으로 응답을 보내지 않은 경우임으로 error


이렇게 됩니다! 

> 기존에 로그인 / 회원가입에 대한 navigate 분기처리가 덜 되어있길래, 이부분도 같이 정리해줬어요 


<br/>


6️⃣ **네 줄 정리 하자면!** 
1. 사용자가 버튼을 누르면 구글 로그인 화면으로 이동 
2. 구글 로그인에 성공할 시, redirect uri (/auth/google)로 이동 
3. /auth/google route인 LoginCallback에서 인가코드 추출 후, 서버에게 요청을 보내서 accessToken을 받아옴 
4. 서버에게 토큰과 함께 응답받은 role의 값에 따라 선배로 로그인 / 후배로 로그인 / 선배로 회원가입 / 후배로 회원가입 페이지로 이동!


---

### 🤙🏻 role 전달 방식 수정 

([관련 commit](https://github.com/TEAM-SEONYAK/SEONYAK_CLIENT/pull/214/commits/1fabd91a3efaf0b087ef4f33284d74076dc56ba8)) 

🍀 **상황** 
useGoogleLoginMutation 에서 선/후배에 따라 다른 페이지로 navigate 시켜주기 위해서 role이 필요해요. 

이때 `로그인`일 경우, 구글로그인 API의 응답으로 서버에서 유저의 role을 보내줘서 그걸 사용하면 되는데, 
`회원가입`일 경우, 서버가 유저의 role을 몰라서 보내주지 않기 때문에 **JoinPage에서 사용자가 `선배로 시작하기` / `후배로 시작하기` 둘 중 어떤 것을 클릭했는지 여부**를 저장했다가 useGoogleLoginMutation에서 사용해야 해요. 

그리고 이 JoinPage에서 클릭하는 시점과 useGoogleLoginMutation이 실행되기까지의 중간 과정이 꽤 복잡하기 때문에, 단순히 navigate state 나 prop 같은걸로 쉽게 넘겨줄 수가 없어요 

🍀 **기존 방식** 
JoinPage에서 `~로 시작하기` 클릭 시 해당하는 role을 **localStorage**에 저장해요. 
그리고 `use~Mutation`에서 localStorage에 저장된 role 값을 꺼내서 사용해요. 

🍀 **문제 의식**
accessToken처럼 **사용자가 서비스를 이용하는 내내 상시 들고다녀야 하는 데이터도 아니고**, 
심지어 **어디에서 어디로 데이터를 옮겨야 하는지 그 루트도 명확한 상황**이기 때문에
localStorage를 사용하는 것은 지양해야 한다고 생각했어요. 
그래서 최대한 prop / state로 role 값을 넘겨주는 방법을 고민해봤습니다. 

🍀 **개선 방식**

1️⃣ `JoinPage -> SignupPage`로 이동 : **navigate state**를 이용해요 (기존 방식 그대로) 
2️⃣ `SignupPage-> googleLogin 함수 실행` : **prop**으로 넘겨줘요 
```
onClick={() => googleLogin(role)
```
3️⃣ `googleLogin -> 구글로그인 화면` :  구글로그인 주소로 이동할 때 **queryString**으로 `state=role`을 담아줘요 
> 이부분에서 조금 많이 헤맸어요. 다른 외부 주소로 이동했다가 돌아오는 과정에서 state를 유지할 방법이 없을까?? -> 방법 있더라구요! ! ! 
구글로그인 페이지로 이동했다가 다시 redirect로 돌아올 때, 구글이 사용하는 queryString 외에 **내가 원하는 queryString**을 추가하고 싶다면 **구글 로그인 페이지 접속 시 `state=~`를 포함**시켜주면 된다고 해요. 그러면 그 `state=~` queryString이 **Redirect URI에도 그대로 담겨져** 온다고 합니다! 

<img width="800" alt="image" src="https://github.com/user-attachments/assets/2c5cc24f-05ed-45ad-a162-d8639c5a4b5e">

4️⃣ `구글로그인 화면 -> LoginCallback` : redirect uri에서 인가코드와 동일하게 role 값도 **queryString에서 추출**해줘요 
> LoginCallback.tsx
```tsx
...
const params = new URLSearchParams(window.location.search);
const role = params.get('state');  // 🟡 여기 추가!! 
const code = params.get('code');
const { mutate: login } = useGoogleLoginMutation({ role: role || undefined }); 
...
```

--- 
## 부록 )
🤙🏻 **합숙 때 저희의 관건이었던... Redirect URI**

> 리디렉 주소 = 사용자가 로그인 성공 시 이동할 주소 

만약 리디렉 주소를 서버 도메인(localhost:8080, 서버 API URL 등)으로 설정한다면, 인가코드는 서버로 보내질테니, 인가코드를 추출하는 로직을 서버측에서 구현해야 해요. 
하지만 저희는 인가코드를 **클라가 받아서 처리해줘야 하는 로직**이기 때문에, (클라가 처리하는게 일반적임) 
리디렉 주소를 클라이언트(웹) 도메인(localhost:5173, seonyak.com) 으로 설정해주어야 합니다. 그래야 사용자가 로그인이 끝나면 **선약 페이지로 이동**할테니까요! 

여기서 진이가 질문했던 부분이 있는데요, 
> 그럼 `/auth/~` 같은 새로운 path를 팔 필요 없이, 원래 사용자가 있던 `/join` 페이지로 redirect 시키면 되는거 아닌가요? 
-> 이래도 됨!! 이건 저도 이번에 진이 질문 덕에 처음 알게 됐어요. 어떠한 주소든 가능하고 서버쪽에서 구글에 리디렉 주소로 등록해주면 그만입니다! 

하지만 별도의 route, 컴포넌트로 분리해주는게 `단일책임원칙`을 고려한 측면에서 더 좋다고 생각해요. 
`JoinPage`는 **사용자를 처음 맞이하는 UI를 보여주는 페이지**이고, 
`Redirect 도착지`의 역할은 **구글로그인 후, 인가코드를 추출하고 이를 서버에게 넘겨서 토큰을 받아오는 역할**을 하는 컴포넌트니까 
둘이 수행하는 역할이 전혀 다르기 때문에 분리해주는게 이상적인 방법이라고 생각했습니다! 

> 참고로 `/auth/google `은 구글에서 정해준 주소가 아니라, 저와 창균이가 정한 주소입니다

<br/>

🤙🏻 **Redirect URI를 코드에 직접 넣지 않고, env로 분리했어요!**
위에서 한번 언급했듯, Redirect URI가 개발 환경, 배포 환경에 따라 달라져야 하기 때문이에요. 
저희 vscode에서 .env 파일에 설정할 때엔 `localhost:5173~` 으로 넣어주고, 
배포한 Vercel에서 환경변수를 설정할 때엔 `seonyak.com~` 으로 넣어줘야 해요! 

> .env 파일은 제가 카톡 공지에 업데이트 해둘게요! 

## 📸 Screenshot

저는 이미 회원가입을 한 상태라서 `선배 로그인` 플로우 영상이에요. 
체크하실 부분은 
- 구글로그인 완료 후 **빈 화면에서 `localhost:5173/auth/google?code=~` 이 주소로 잠시 이동**하는 모습 
(redirect uri에서 인가코드 추출하고 엑세스 토큰 발급받는 과정이 진행되는 중인거임) 
- 모든 로그인 과정이 끝나면 홈 화면으로 이동되면서 **localStorage에 role과 accessToken이 잘 저장되는 모습** 

https://github.com/user-attachments/assets/a906624a-897c-4202-89cb-05dcb5115fe9


<!-- (선택) 구현한 부분 스크린샷 남기기 -->


---

p.s. 최대한 구체적으로 작성해보려고 했는데, 워낙 굵직한 작업이다보니 이것만 읽고 이해하긴 어려울 수 있어요 ㅠㅠ 이해 안되는 부분 코드리뷰 달아주시면 추가 설명 드릴테니 편히 달아주세용 