### PR TITLE
[ Refactor ] 프롭스 줄이기, 필터 선택시 깜빡임 제거, 주석 제거

### DIFF
--- a/src/hooks/seniorProfileQueries.ts
+++ b/src/hooks/seniorProfileQueries.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { getSeniorProfile, GetSeniorProfileResponse } from '@pages/juniorPromise/apis/getSeniorProfile';
 
 const useSeniorProfileQueries = (selectedFields: string[], selectedPositions: string[]) => {
@@ -9,6 +9,7 @@ const useSeniorProfileQueries = (selectedFields: string[], selectedPositions: st
   const { data, isLoading, isError } = useQuery<GetSeniorProfileResponse>({
     queryKey: [QUERY_KEY.SENIOR_PROFILE, selectedFields, selectedPositions],
     queryFn: () => getSeniorProfile(selectedFields, selectedPositions),
+    placeholderData: keepPreviousData,
   });
 
   return { data, isLoading, isError };

--- a/src/pages/juniorPromise/JuniorPromisePage.tsx
+++ b/src/pages/juniorPromise/JuniorPromisePage.tsx
@@ -23,12 +23,10 @@ const JuniorPromisePage = () => {
   const handleFilterActiveBtn = (btnText: string) => {
     setFilterActiveBtn(btnText);
     setIsBottomSheetOpen(true);
-    document.body.style.overflow = 'hidden';
   };
   // 바텀시트 닫기
   const handleCloseBottomSheet = () => {
     setIsBottomSheetOpen(false);
-    document.body.style.overflow = 'auto';
   };
 
   // 바텀시트 내 직무 칩

--- a/src/pages/juniorPromise/JuniorPromisePage.tsx
+++ b/src/pages/juniorPromise/JuniorPromisePage.tsx
@@ -243,8 +243,10 @@ const SeniorListWrapper = styled.div`
 
 const Background = styled.div`
   position: relative;
-  height: 18.7rem;
+
   width: 100vw;
+  height: 18.7rem;
+
   background: linear-gradient(151deg, #cce7ff 17.85%, #b8b1ff 163.57%);
 `;
 

--- a/src/pages/juniorPromise/JuniorPromisePage.tsx
+++ b/src/pages/juniorPromise/JuniorPromisePage.tsx
@@ -14,7 +14,7 @@ import Loading from '@components/commons/Loading';
 import { HbHomeMainSvg } from '@assets/svgs';
 
 const JuniorPromisePage = () => {
-  // 필터 버튼
+  // 바텀 시트 내 버튼& 내용 필터 버튼
   const [filterActiveBtn, setFilterActiveBtn] = useState('계열');
   // 바텀 시트 여는 동작
   const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
@@ -64,10 +64,10 @@ const JuniorPromisePage = () => {
   };
 
   // 선택된 직무 칩 수
-  const getPositionTrueNum = (arrPosition: boolean[]) => {
-    return arrPosition.filter((n) => n).length;
-  };
-  const positionChipNum = getPositionTrueNum(arrPosition);
+  // const getPositionTrueNum = (arrPosition: boolean[]) => {
+  //   return arrPosition.filter((n) => n).length;
+  // };
+  // const positionChipNum = getPositionTrueNum(arrPosition);
   // 칩으로 나갈 선택된 계열 이름 리스트
   const [chipFieldName, setChipFieldName] = useState<string[]>([]);
 
@@ -99,7 +99,7 @@ const JuniorPromisePage = () => {
       }
     });
   };
-  // 직무리스트에 이름빼는 함수
+  // 직무리스트에 이름 빼는 함수
   const deletePositionList = (chipName: string) => {
     setChipPositionName((prev) => prev.filter((name) => name !== chipName));
   };
@@ -160,11 +160,10 @@ const JuniorPromisePage = () => {
           <SeniorListBackground
             handleFilterActiveBtn={handleFilterActiveBtn}
             handleReset={handleReset}
-            positionChipNum={positionChipNum}
+            chipPositionName={chipPositionName}
             chipFieldName={chipFieldName}
             deleteFieldList={deleteFieldList}
             handleChipField={handleChipField}
-            chipPositionName={chipPositionName}
             deletePositionList={deletePositionList}
             handleChipPosition={handleChipPosition}
             $chipFieldName={chipFieldName}

--- a/src/pages/juniorPromise/JuniorPromisePage.tsx
+++ b/src/pages/juniorPromise/JuniorPromisePage.tsx
@@ -4,7 +4,7 @@ import Nav from '@components/commons/Nav';
 import { SeniorCard } from '@components/commons/SeniorCard';
 import styled from '@emotion/styled';
 import { BottomSheet } from '@pages/juniorPromise/components/BottomSheetBg';
-import { useState, useEffect, useRef } from 'react';
+import { useState } from 'react';
 import { SeniorListBackground } from './components/SeniorListBackground';
 import seniorProfileQueries from '../../hooks/seniorProfileQueries';
 import PreView from '@pages/seniorProfile/components/preView';
@@ -18,14 +18,6 @@ const JuniorPromisePage = () => {
   const [filterActiveBtn, setFilterActiveBtn] = useState('계열');
   // 바텀 시트 여는 동작
   const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
-
-  const wrapperRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (wrapperRef.current) {
-      wrapperRef.current.style.position = isBottomSheetOpen ? 'fixed' : 'relative';
-    }
-  }, [isBottomSheetOpen]);
 
   // 필터 버튼에 정보 넣기, 바텀시트 열기
   const handleFilterActiveBtn = (btnText: string) => {
@@ -150,7 +142,7 @@ const JuniorPromisePage = () => {
           <FullBtn text="약속 신청하기" onClick={handlePromiseClicked} />
         </>
       ) : (
-        <Wrapper ref={wrapperRef}>
+        <Wrapper isBottomSheetOpen={isBottomSheetOpen}>
           <Header LeftSvg={HeaderLogoIc} RightSvg={AlarmIc} bgColor="transparent" />
           <Background>
             <HbHomeMainSvgIcon />
@@ -211,7 +203,10 @@ const JuniorPromisePage = () => {
 };
 
 export default JuniorPromisePage;
-const Wrapper = styled.div`
+
+const Wrapper = styled.div<{ isBottomSheetOpen: boolean }>`
+  position: ${({ isBottomSheetOpen }) => (isBottomSheetOpen ? 'fixed' : 'relative')};
+
   min-height: calc(var(--vh, 1vh) * 100 - 44px);
 
   background-color: ${({ theme }) => theme.colors.grayScaleWG};

--- a/src/pages/juniorPromise/JuniorPromisePage.tsx
+++ b/src/pages/juniorPromise/JuniorPromisePage.tsx
@@ -4,7 +4,7 @@ import Nav from '@components/commons/Nav';
 import { SeniorCard } from '@components/commons/SeniorCard';
 import styled from '@emotion/styled';
 import { BottomSheet } from '@pages/juniorPromise/components/BottomSheetBg';
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { SeniorListBackground } from './components/SeniorListBackground';
 import seniorProfileQueries from '../../hooks/seniorProfileQueries';
 import PreView from '@pages/seniorProfile/components/preView';
@@ -18,6 +18,14 @@ const JuniorPromisePage = () => {
   const [filterActiveBtn, setFilterActiveBtn] = useState('계열');
   // 바텀 시트 여는 동작
   const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
+
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (wrapperRef.current) {
+      wrapperRef.current.style.position = isBottomSheetOpen ? 'fixed' : 'relative';
+    }
+  }, [isBottomSheetOpen]);
 
   // 필터 버튼에 정보 넣기, 바텀시트 열기
   const handleFilterActiveBtn = (btnText: string) => {
@@ -142,7 +150,7 @@ const JuniorPromisePage = () => {
           <FullBtn text="약속 신청하기" onClick={handlePromiseClicked} />
         </>
       ) : (
-        <Wrapper>
+        <Wrapper ref={wrapperRef}>
           <Header LeftSvg={HeaderLogoIc} RightSvg={AlarmIc} bgColor="transparent" />
           <Background>
             <HbHomeMainSvgIcon />

--- a/src/pages/juniorPromise/JuniorPromisePage.tsx
+++ b/src/pages/juniorPromise/JuniorPromisePage.tsx
@@ -63,11 +63,6 @@ const JuniorPromisePage = () => {
     setChipPositionName([]);
   };
 
-  // 선택된 직무 칩 수
-  // const getPositionTrueNum = (arrPosition: boolean[]) => {
-  //   return arrPosition.filter((n) => n).length;
-  // };
-  // const positionChipNum = getPositionTrueNum(arrPosition);
   // 칩으로 나갈 선택된 계열 이름 리스트
   const [chipFieldName, setChipFieldName] = useState<string[]>([]);
 

--- a/src/pages/juniorPromise/components/FilterButton.tsx
+++ b/src/pages/juniorPromise/components/FilterButton.tsx
@@ -3,12 +3,12 @@ import React from 'react';
 import { ArrowDownIc } from '../../../assets/svgs/index';
 interface FilterButtonProps {
   handleFilterActiveBtn: (btnText: string) => void;
-  positionChipNum: number;
+  chipPositionName: string[];
   chipFieldName: string[];
 }
 export const FilterButton: React.FC<FilterButtonProps> = ({
   handleFilterActiveBtn,
-  positionChipNum,
+  chipPositionName,
   chipFieldName,
 }) => {
   return (
@@ -22,10 +22,13 @@ export const FilterButton: React.FC<FilterButtonProps> = ({
         <FieldArrowDownIc chipfieldname={chipFieldName.length + ''} />
       </FilterFieldBtn>
 
-      <FilterPositionBtn type="button" onClick={() => handleFilterActiveBtn('직무')} $positionChipNum={positionChipNum}>
-        <PositionName $positionChipNum={positionChipNum}>직무</PositionName>
-        {positionChipNum > 0 && <ChipNum>{positionChipNum}</ChipNum>}
-        <PositionArrowDown positionchipnum={positionChipNum + ''} />
+      <FilterPositionBtn
+        type="button"
+        onClick={() => handleFilterActiveBtn('직무')}
+        $chipPositionNameNum={chipPositionName.length}>
+        <PositionName $positionChipNum={chipPositionName.length}>직무</PositionName>
+        {chipPositionName.length > 0 && <ChipNum>{chipPositionName.length}</ChipNum>}
+        <PositionArrowDown chippositionname={chipPositionName.length + ''} />
       </FilterPositionBtn>
     </FilterBtnContainer>
   );
@@ -51,7 +54,7 @@ const FilterFieldBtn = styled.button<{ $chipFieldNameNum: number }>`
 
   ${({ theme }) => theme.fonts.Caption2_SB_12};
 `;
-const FilterPositionBtn = styled.button<{ $positionChipNum: number }>`
+const FilterPositionBtn = styled.button<{ $chipPositionNameNum: number }>`
   display: flex;
   gap: 1rem;
   justify-content: center;
@@ -59,11 +62,11 @@ const FilterPositionBtn = styled.button<{ $positionChipNum: number }>`
 
   padding: 0.8rem 1rem;
   border: 1px solid
-    ${({ theme, $positionChipNum }) => ($positionChipNum > 0 ? theme.colors.Blue : theme.colors.grayScaleWG)};
+    ${({ theme, $chipPositionNameNum }) => ($chipPositionNameNum > 0 ? theme.colors.Blue : theme.colors.grayScaleWG)};
   border-radius: 6px;
 
-  background: ${({ theme, $positionChipNum }) =>
-    $positionChipNum > 0 ? theme.colors.primaryBlue100 : theme.colors.grayScaleLG2};
+  background: ${({ theme, $chipPositionNameNum }) =>
+    $chipPositionNameNum > 0 ? theme.colors.primaryBlue100 : theme.colors.grayScaleLG2};
 
   ${({ theme }) => theme.fonts.Caption2_SB_12};
 `;
@@ -85,8 +88,8 @@ const FieldArrowDownIc = styled(ArrowDownIc)<{ chipfieldname: string }>`
   }
 `;
 
-const PositionArrowDown = styled(ArrowDownIc)<{ positionchipnum: string }>`
+const PositionArrowDown = styled(ArrowDownIc)<{ chippositionname: string }>`
   path {
-    stroke: ${({ theme, positionchipnum }) => (positionchipnum > '0' ? theme.colors.Blue : theme.colors.grayScaleDG)};
+    stroke: ${({ theme, chippositionname }) => (chippositionname > '0' ? theme.colors.Blue : theme.colors.grayScaleDG)};
   }
 `;

--- a/src/pages/juniorPromise/components/SeniorListBackground.tsx
+++ b/src/pages/juniorPromise/components/SeniorListBackground.tsx
@@ -4,17 +4,15 @@ import React, { ReactNode } from 'react';
 import { FilterButton } from './FilterButton';
 import { FIELD_LIST } from '../constants/fieldList';
 import { POSITION_LIST } from '../constants/positionList';
-// import { POSITION_LIST } from '../constants/positionList';
 
 interface SeniorListBackgroundProps {
   children: ReactNode;
   handleFilterActiveBtn: (btnText: string) => void;
   handleReset: () => void;
-  positionChipNum: number;
+  chipPositionName: string[];
   chipFieldName: string[];
   deleteFieldList: (chipName: string) => void;
   handleChipField: (fieldId: number) => void;
-  chipPositionName: string[];
   deletePositionList: (chipName: string) => void;
   handleChipPosition: (postion: number) => void;
   $chipFieldName: string[];
@@ -29,7 +27,6 @@ export const SeniorListBackground: React.FC<SeniorListBackgroundProps> = ({
   children,
   handleFilterActiveBtn,
   handleReset,
-  positionChipNum,
   chipFieldName,
   deleteFieldList,
   handleChipField,
@@ -56,7 +53,7 @@ export const SeniorListBackground: React.FC<SeniorListBackgroundProps> = ({
         <BtnLayout>
           <FilterButton
             handleFilterActiveBtn={handleFilterActiveBtn}
-            positionChipNum={positionChipNum}
+            chipPositionName={chipPositionName}
             chipFieldName={chipFieldName}
           />
           <LineWrapper>
@@ -126,8 +123,6 @@ const SelectedChipList = styled.div<SelectedChipListProps>`
     $chipFieldName.length > 0 || $chipPositionName.length > 0 ? 'flex' : 'none'};
   gap: 0.8rem;
   align-items: center;
-
-  /* 필요에 따라 가로 스크롤바 생성 */
   overflow: scroll hidden;
 
   height: 4.4rem;


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #215 

## ✅ Done Task
  - [x] 스타일린트 미적용된 부분 수정
  - [x] 불필요한 주석 제거
  - [x] 불필요한 프롭스 줄이기

## 💎 PR Point
우선.. pr이 이렇게 짧아도 되나.. 걱정되지만,, 일단 오늘치 리팩토링한 부분 pr 올려봅니다..!!

1️⃣ 프롭스 제거_positionChipNum
저의 부분은 field, position 두 개의 필터에 대해 동일한 로직이 2번씩 반복되는 데요..
field는 가지지않는 position만 있는 props입니다.

<img width="378" alt="스크린샷 2024-08-07 오전 12 54 02" src="https://github.com/user-attachments/assets/2725f92d-963a-437d-9b49-7f4c01f0b157">

선택된 직무의 개수에따라 숫자가 변하는 부분입니다!

```typescript
// 선택된 직무 칩 수
const getPositionTrueNum = (arrPosition: boolean[]) => {
  return arrPosition.filter((n) => n).length;
};
const positionChipNum = getPositionTrueNum(arrPosition);
```
요놈인데요.. 
field의 경우

```typescript
  // 칩으로 나갈 선택된 계열 이름 리스트
  const [chipFieldName, setChipFieldName] = useState<string[]>([]);
```
이 배열의 길이로 숫자를 적용해서, position도 동일하게 바꾸었습니다..! 자자잔

```typescript
{chipPositionName.length > 0 && <ChipNum>{chipPositionName.length}</ChipNum>}
```
이상입니다,, 오늘치 리팩토링이고 다음번 pr은 좀 더 옹골찬 props사망사건으로 찾아뵙겠습니다.. 총총..

2️⃣ 필터 적용시 깜빡임 제거
 아래 첫번째 동영상 보시면 바텀시트 내 필터를 적용할때마다 화면이 깜빡이는 것을 확인하실 수 있는데요,,
```typescript
   placeholderData: keepPreviousData,
```
위의 코드로 해결했습니다..
이 부분에 대한 내용은 아래의 댓글에서 확인해주세요!
## 📸 Screenshot

- 코드 변경 후 기존과 동일하게 작동!

https://github.com/user-attachments/assets/def76975-4d04-4cf8-aca6-85f81a9a80e1

- 필터 적용시 깜빡임 제거

https://github.com/user-attachments/assets/c9176c40-ef38-44cf-b3d4-64b574a20975



