### PR TITLE
[ design ] 후배 약속 리스트 - 텅 뷰 가운데 정렬

### DIFF
--- a/src/pages/promiseList/components/RecentCard.tsx
+++ b/src/pages/promiseList/components/RecentCard.tsx
@@ -68,7 +68,7 @@ const RecentCard = (props: RecentCardPropType) => {
           />
         </>
       ) : (
-        <EmptyImg />
+        <EmptyImage />
       )}
     </Wrapper>
   );
@@ -107,4 +107,8 @@ const DashedDivider = styled.div`
   height: 0.1rem;
   margin-bottom: 1.39rem;
   border-bottom: 1px dashed ${({ theme }) => theme.colors.grayScaleLG1};
+`;
+
+const EmptyImage = styled(EmptyImg)`
+  width: 100%;
 `;


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #219 

## ✅ Done Task
  - [x] 후배 약속 리스트 - 텅 뷰 가운데 정렬

## ☀️ New-insight
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->
- 추출한 svg가 아이폰 SE에만 맞는 사이즈여서 모든 부분에서 전체 사이즈 차지하도록 변경했습니다 ~

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->
- 너무 간단한 거라 없음
- 간단한 거라 걍 다 담 ㅋ

## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->

https://github.com/user-attachments/assets/a2d28200-aba0-4996-8f43-2ac946db3da7

