### PR TITLE
[Fix] 바텀시트 내부 버튼 폭 수정 및 컨텐츠 간격 조정

### DIFF
--- a/src/components/commons/ToggleButton.tsx
+++ b/src/components/commons/ToggleButton.tsx
@@ -31,7 +31,7 @@ const Wrapper = styled.div`
 const Layout = styled.div`
   display: flex;
 
-  width: 33.7rem;
+  width: 100%;
   height: 4.4rem;
   border-radius: 8px;
 

--- a/src/pages/juniorPromise/components/BottomSheetBg.tsx
+++ b/src/pages/juniorPromise/components/BottomSheetBg.tsx
@@ -46,12 +46,15 @@ export const BottomSheet = (props: BottomSheetPropType) => {
           <Title>원하는 선배를 찾아볼까요?</Title>
           <Desc>계열, 직무로 원하는 선배를 찾을 수 있어요.</Desc>
         </TitleLayout>
-        <ToggleButton
-          left="계열"
-          right="직무"
-          activeButton={filterActiveBtn}
-          onSetActiveButtonHandler={handleFilterActiveBtn}
-        />
+        <ToggleLayout>
+          <ToggleButton
+            left="계열"
+            right="직무"
+            activeButton={filterActiveBtn}
+            onSetActiveButtonHandler={handleFilterActiveBtn}
+          />
+        </ToggleLayout>
+
         <Content>
           {filterActiveBtn === '계열' ? (
             <FieldLayout>
@@ -135,6 +138,10 @@ const BottomSheetWrapper = styled.form<{ $isBottomSheetOpen: boolean }>`
 
 const TitleLayout = styled.header`
   padding: 1.4rem 16.1rem 1.6rem 2rem;
+`;
+
+const ToggleLayout = styled.div`
+  margin: 0 2rem;
 `;
 
 const Content = styled.div`

--- a/src/pages/juniorPromise/components/BottomSheetBg.tsx
+++ b/src/pages/juniorPromise/components/BottomSheetBg.tsx
@@ -156,7 +156,7 @@ const FieldLayout = styled.div`
   justify-content: space-between;
 
   margin: 0 2rem;
-  padding: 1rem 0;
+  padding: 1.5rem 0;
 `;
 
 const PositionLayout = styled.div`
@@ -165,7 +165,7 @@ const PositionLayout = styled.div`
   gap: 1.2rem 1rem;
   flex-shrink: 0;
 
-  margin: 1rem 2rem;
+  margin: 1.5rem 2rem;
 `;
 
 const Line = styled.div`

--- a/src/pages/juniorPromise/components/BottomSheetBg.tsx
+++ b/src/pages/juniorPromise/components/BottomSheetBg.tsx
@@ -41,8 +41,10 @@ export const BottomSheet = (props: BottomSheetPropType) => {
     <>
       <Background $isBottomSheetOpen={isBottomSheetOpen} onClick={handleCloseBottomSheet} />
       <BottomSheetWrapper $isBottomSheetOpen={isBottomSheetOpen}>
-        <TitleLayout>
+        <LineBox>
           <Line />
+        </LineBox>
+        <TitleLayout>
           <Title>원하는 선배를 찾아볼까요?</Title>
           <Desc>계열, 직무로 원하는 선배를 찾을 수 있어요.</Desc>
         </TitleLayout>
@@ -137,7 +139,9 @@ const BottomSheetWrapper = styled.form<{ $isBottomSheetOpen: boolean }>`
 `;
 
 const TitleLayout = styled.header`
-  padding: 1.4rem 16.1rem 1.6rem 2rem;
+  display: inline-block;
+
+  margin: 0 2rem 1.5rem;
 `;
 
 const ToggleLayout = styled.div`
@@ -168,10 +172,18 @@ const PositionLayout = styled.div`
   margin: 1.5rem 2rem;
 `;
 
+const LineBox = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  width: 100%;
+  height: 3.3rem;
+`;
+
 const Line = styled.div`
   width: 4.7rem;
   height: 0.3rem;
-  margin: 0 14.4rem 3.3rem;
   border-radius: 5px;
 
   background: ${({ theme }) => theme.colors.grayScaleLG2};

--- a/src/pages/juniorPromise/components/BottomSheetBg.tsx
+++ b/src/pages/juniorPromise/components/BottomSheetBg.tsx
@@ -200,7 +200,8 @@ const ReloadIcon = styled.button`
 `;
 
 const ExitBottomSheet = styled.button<{ $selectedPositionIndex: boolean; $selectedFieldIndex: boolean }>`
-  width: 27.4rem;
+  flex-grow: 1;
+
   height: 5rem;
   border-radius: 8px;
 

--- a/src/pages/juniorPromise/components/BottomSheetBg.tsx
+++ b/src/pages/juniorPromise/components/BottomSheetBg.tsx
@@ -139,8 +139,6 @@ const BottomSheetWrapper = styled.form<{ $isBottomSheetOpen: boolean }>`
 `;
 
 const TitleLayout = styled.header`
-  display: inline-block;
-
   margin: 0 2rem 1.5rem;
 `;
 


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #231 

## ✅ Done Task
 [x] 바텀시트 내부 버튼 사이즈 폭 조정
 [x] 컨텐츠 간격 조정

## ☀️ New-insight
다양한 사이즈에 대응하기 위해 구체적인 사이즈를 지정하는 것을 지양해야겠다는 생각이 들었어요!



## 💎 PR Point
1️⃣ 공통 컴포넌트(Toggle) 폭 수정
: 해당 컴포넌트는 지은, 예림 뷰에서만 사용되는 공통 컴포넌트입니다. 
지은 뷰에서 폭 100%로 수정하여 피그마 뷰와 일치 시켰고, 제 컴포넌트에서 별도의 레이아웃을 추가하여 조정 완료 했습니다!

2️⃣ 바텀시트 하단 버튼 폭 수정
: `width: 27.4rem;`
구체적인 사이즈를 지정한 기존의 코드를 삭제하고
아래의 내용으로 수정하여 피그마 뷰와 일치 시켰습니다!
`  flex-grow: 1;`

3️⃣ 바텀시트 내부 컨텐츠 간격 조정
: 기존 1rem을 피그마 뷰와 동일하게 1.5rem으로 수정하였습니다.

🍀 추가적으로 공통 토글 컴포넌트는 지은이 컴포넌트라 코리 페어는 아니지만 지은이도 코드리뷰어로 소환하였습니다! 
지은이는 1️⃣번의 내용만 확인해주시면 될 거 같습니당!
🍀 브랜치명이 적합하지 않다고 생각되어 머지할때 수정하겠습니다!

## 📸 Screenshot
1️⃣,2️⃣,3️⃣번의 내용 모두 아래의 사진으로 확인해주시면 감사하겠습니다!

- 모바일 뷰에서의 바텀시트
<img width="242" alt="스크린샷 2024-09-17 오전 12 23 48" src="https://github.com/user-attachments/assets/abd82cfe-341c-4a86-b1fe-0650af425348">

- 모바일뷰 풀었을때
<img width="436" alt="스크린샷 2024-09-17 오전 1 33 56" src="https://github.com/user-attachments/assets/4068e70f-ccb9-4b6c-b609-665cdff7d2f6">

- 바텀시트 내부 핸들바 중앙정렬 사이즈별 동영상

https://github.com/user-attachments/assets/e7bc1196-130e-490f-9846-352a0216fd82


