### PR TITLE
[ Fix ] 닉네임 중복체크 재검사 시 초기화 & 409에러 중복처리 

### DIFF
--- a/src/pages/onboarding/components/commonOnboarding/Step개인정보입력.tsx
+++ b/src/pages/onboarding/components/commonOnboarding/Step개인정보입력.tsx
@@ -18,8 +18,8 @@ const Step개인정보입력 = () => {
   const navigate = useNavigate();
   const [nickname, setNickname] = useState(data.nickname);
   const mutation = useNicknameValid();
-  const [isNicknameError, setNicknameError] = useState(false);
-  const [isNicknameValid, setIsNicknameValid] = useState(false);
+  type nicknameStatusType = 'EMPTY' | 'ERROR' | 'VALID';
+  const [isNicknameStatus, setIsNicknameStatus] = useState<nicknameStatusType>('EMPTY');
 
   const [imageFile, setImageFile] = useState<File | null>(data.imageFile || null);
 
@@ -38,19 +38,17 @@ const Step개인정보입력 = () => {
     setNickname(e.target.value);
 
     if (e.target.value.length == 0) {
-      setNicknameError(false);
-      setIsNicknameValid(false);
+      setIsNicknameStatus('EMPTY');
     }
   };
 
   const handleCheckNickname = () => {
     mutation.mutate(nickname, {
       onSuccess: () => {
-        setIsNicknameValid(true);
+        setIsNicknameStatus('VALID');
       },
       onError: () => {
-        setNicknameError(true);
-        setIsNicknameValid(false);
+        setIsNicknameStatus('ERROR');
       },
     });
   };
@@ -86,21 +84,23 @@ const Step개인정보입력 = () => {
           <InputBox
             label="닉네임"
             placeholder="닉네임을 입력해 주세요"
-            isError={isNicknameError}
+            isError={isNicknameStatus === 'ERROR'}
             value={nickname}
             onChange={handleChangeInput}>
             <InnerButton text="중복확인" onClick={handleCheckNickname} />
           </InputBox>
-          {isNicknameError ? (
-            <WarnDescription isShown={isNicknameError} warnText="닉네임이 조건을 충족하지 않아요." />
+          {isNicknameStatus === 'ERROR' ? (
+            <WarnDescription isShown warnText="닉네임이 조건을 충족하지 않아요." />
           ) : (
-            <Caption isValid={isNicknameValid}>
-              {isNicknameValid ? '사용 가능한 닉네임이에요' : '8자리 이내, 문자/숫자 가능, 특수문자/기호 입력 불가'}
+            <Caption isValid={isNicknameStatus === 'VALID'}>
+              {isNicknameStatus === 'VALID'
+                ? '사용 가능한 닉네임이에요'
+                : '8자리 이내, 문자/숫자 가능, 특수문자/기호 입력 불가'}
             </Caption>
           )}
         </TextBox>
       </div>
-      <FullBtn onClick={handleClickLink} isActive={isNicknameValid} />
+      <FullBtn onClick={handleClickLink} isActive={isNicknameStatus === 'VALID'} />
     </>
   );
 };

--- a/src/pages/onboarding/hooks/useNicknameQuery.ts
+++ b/src/pages/onboarding/hooks/useNicknameQuery.ts
@@ -1,12 +1,9 @@
-import { nicknameAxios } from "@pages/onboarding/apis/nicknameAxios"
-import { useMutation } from "@tanstack/react-query"
+import { nicknameAxios } from '@pages/onboarding/apis/nicknameAxios';
+import { useMutation } from '@tanstack/react-query';
 
 const useNicknameValid = () => {
   const mutation = useMutation({
     mutationFn: (nickname: string) => nicknameAxios(nickname),
-    onError: (error) => {
-      console.log('nickname post Error: ', error)
-    }
   });
 
   return mutation;


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #246 

## ✅ Done Task
  - [x] `중복된 닉네임 -> 닉네임 수정 후 재검사 -> 계속 중복 오류 지속` 해당 문제 해결 
  - [x] 중복된 닉네임 (409 conflict 에러) 분기 처리 

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->

### 1) `중복된 닉네임 -> 닉네임 수정 후 재검사 -> 계속 중복 오류 지속` 해당 문제 해결    
[관련 커밋](https://github.com/TEAM-SEONYAK/SEONYAK_CLIENT/commit/0e7662fe4c832de902408f3d82acdf381fb6aeb6) 
이미 존재하는 닉네임을 입력하고 중복확인을 눌러서 중복 에러가 발생하고 -> 이후 중복되지 않는 정상 닉네임으로 수정하고 다시 중복확인을 클릭했는데 -> API는 성공함에도 불구하고 에러박스는 유지되는 문제가 있었습니다. 

nickname 상태 관련 state를 isNicknameValid와 isNicknameError 이렇게 두개를 사용해주고 있었는데 
닉네임 중복체크 에러가 발생했을 때 setNicknameError(true)는 해주면서 setNicknameValid(false)는 해주지 않아서 생긴 문제였어요. 

그런데 이렇게 동일한 '닉네임의 유효성'에 대한 상태를 여러개의 state로 관리해주는게 좋지 못한 방식이라는 생각이 들었어요. 
그래서 하나의 state로 통합 관리 하도록 수정해주었습니다. 

대신 가능한 닉네임 유효성 상태가 여러개라서 기존처럼 boolean 타입을 사용하지는 못하구요 
- 유효함 : VALID
- 공백 (에러도 아니지만 유효하지도 않음) : EMPTY
- 에러 : (2번에서 부연설명) INVALID, CONFLICT

이렇게 문자열값으로 상태 관리 방식 수정하였습니다 


### 2) Input 중복체크 에러메시지 수정
[관련 커밋](https://github.com/TEAM-SEONYAK/SEONYAK_CLIENT/commit/866bb5e1d7ef463949c92f7b4ef80e41f22b7379) 
기존에 `닉네임 조건으로 인한 에러` & `닉네임 중복으로 인한 에러` -> 별도로 분기 처리를 안해주고 있었어요. 
그래서 중복된 닉네임으로 인한 에러도 '닉네임 조건이 충족하지 않는다' 는 에러메시지를 보여주고 있었어요 
이부분을 분기처리해주었습니다. 

중복으로 인한 에러가 발생할 땐 에러 코드가 409라서 이걸로 조건 검사해서 분기해주었고, 
1번에서 닉네임 status state를 string으로 관리해주기로 해서 
- 중복 에러일 때 : `CONFLICT`
- 그 외의 에러일 때 (조건불충족 등) : `INVALID`

이렇게 설정해주었습니다! 


## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->
### 1) `중복된 닉네임 -> 닉네임 수정 후 재검사 -> 계속 중복 오류 지속` 해당 문제 해결    
**🪫 전** 
오른쪽 네트워크 탭 보시면 nickname API 통신 실패했다가 두번째는 성공했는데 뷰에서는 여전히 에러박스를 보여주고 있죠 
![image](https://github.com/user-attachments/assets/f2ffc2ce-7f77-47c9-956b-aad3f0c20881)


**🔋 후**
해결해서 이렇게 실패후 성공할 경우 올바르게 에러박스 사라지도록 수정 되었습니다 
![image](https://github.com/user-attachments/assets/7d07994f-0975-4302-8bdf-570b0e102d9a)



### 2) Input 중복체크 에러메시지 수정
**🪫 전** 
![image](https://github.com/user-attachments/assets/d54ed6c3-ec6b-4312-b8ed-62354511ebfb)

**🔋 후**
![image](https://github.com/user-attachments/assets/7731e710-d80f-4a4f-9f49-5e1b32138d3b)
