### PR TITLE
[ Fix/#249 ] 선배 nav바 둘러보기 탭 클릭 막기, promiseList 페이지 콘솔에 key값 중복 에러 나는 거 해결

### DIFF
--- a/src/components/commons/Nav.tsx
+++ b/src/components/commons/Nav.tsx
@@ -3,13 +3,11 @@ import { useState, useEffect } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { NaviLookBlackIc, NaviPromiseBlackIc, NaviMyBlackIc } from '../../assets/svgs';
 
-type UserRole = 'JUNIOR' | 'SENIOR';
-
 const Nav = () => {
   const navigate = useNavigate();
   const location = useLocation();
 
-  const [userRole] = useState<UserRole>('JUNIOR');
+  const userRole = localStorage.getItem('role') + '';
   const [currNav, setCurrNav] = useState(location.pathname);
 
   useEffect(() => {

--- a/src/pages/promiseList/components/PromiseTap.tsx
+++ b/src/pages/promiseList/components/PromiseTap.tsx
@@ -47,20 +47,20 @@ const PromiseTap = (props: PromiseTapPropType) => {
       {getTapContent(tap).length ? (
         <ProfileWrapper>
           {tap === 'past' &&
-            past.map((profileData, idx) =>
+            past.map((profileData) =>
               profileData.appointmentStatus === 'REJECTED' ? (
                 <ProfileContainer
-                  key={profileData.appointmentId + idx}
+                  key={profileData.appointmentId}
                   myNickname={myNickname}
                   userRole={userRole}
                   tap="rejected"
                   profileCardData={profileData}
-                  isarrow="ture"
+                  isarrow="true"
                   seniorId={profileData.seniorId}
                 />
               ) : (
                 <ProfileContainer
-                  key={profileData.appointmentId + idx}
+                  key={profileData.appointmentId}
                   myNickname={myNickname}
                   userRole={userRole}
                   tap="past"
@@ -68,14 +68,14 @@ const PromiseTap = (props: PromiseTapPropType) => {
                   isarrow="true"
                   seniorId={profileData.seniorId}
                 />
-              ),
+              )
             )}
 
           {tap === 'scheduled' &&
-            scheduled.map((profileCardData, idx) => (
+            scheduled.map((profileCardData) => (
               <ProfileContainer
                 myNickname={myNickname}
-                key={profileCardData.appointmentId + idx}
+                key={profileCardData.appointmentId}
                 userRole={userRole}
                 tap={tap}
                 profileCardData={profileCardData}
@@ -84,10 +84,10 @@ const PromiseTap = (props: PromiseTapPropType) => {
               />
             ))}
           {tap === 'pending' &&
-            pending.map((profileCardData, idx) => (
+            pending.map((profileCardData) => (
               <ProfileContainer
                 myNickname={myNickname}
-                key={profileCardData.appointmentId + idx}
+                key={profileCardData.appointmentId}
                 userRole={userRole}
                 tap={tap}
                 profileCardData={profileCardData}


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #249 

## ✅ Done Task
  - [x] 선배 nav바 둘러보기 탭 클릭 막기
  - [x]  promiseList 페이지 콘솔에 key값 중복 에러 나는 거 해결

## ☀️ New-insight
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->
- 선배 nav바 둘러보기 탭 클릭 막기
앱잼단에서 role 받아오기 전에 JUNIOR로 하드코딩해둔게 남아있어서 접근이 가능했더라구요. localStorage에서 받아오는 걸로 로직 변경했습니다

- promiseList 페이지 콘솔에 key값 중복 에러 나는 거 해결
기존에는 appointmentId + idx 로 key값을 부여했는데, 생각해보니까 appointmentId는 약속마다 고유하기 때문에 굳이 idx를 추가해서 만들어줄 필요가 없더라구요? 따라서 appointmentId로만 key부여했고, 중복 에러도 없어졌습니당!

## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->
- 선배 nav바 둘러보기 탭 클릭 막기

https://github.com/user-attachments/assets/5066f2eb-2603-4f27-98b5-09f0f152dfee


- promiseList 페이지 콘솔에 key값 중복 에러 나는 거 해결
기존
![image](https://github.com/user-attachments/assets/93c461f7-e4e3-4290-a8bb-144fe483fd9e)

변경 후

https://github.com/user-attachments/assets/5b6b750d-b707-40b8-b118-7300924d7d1a

