### PR TITLE
[ Fix ] navigate 오류 수정 1

### DIFF
--- a/src/pages/onboarding/components/commonOnboarding/Step번호입력.tsx
+++ b/src/pages/onboarding/components/commonOnboarding/Step번호입력.tsx
@@ -15,6 +15,7 @@ import { 이미_사용중인_전화번호_에러코드 } from '@pages/onboarding
 import { SuccessImg } from '@assets/images';
 import { JoinContextType } from '@pages/onboarding/type';
 import useJoinQuery from '@pages/onboarding/hooks/useJoinQuery';
+import googleLogin from '@pages/login/utils/googleLogin';
 
 const Step번호입력 = () => {
   const { data, setData } = useOutletContext<JoinContextType>();
@@ -156,7 +157,7 @@ const Step번호입력 = () => {
             setValidCodeError(true);
           }
         },
-      },
+      }
     );
   };
 
@@ -210,9 +211,7 @@ const Step번호입력 = () => {
         isModalOpen={isAlreadyModalOpen}
         handleModalOpen={handleShowAlreadyModal}
         btnText="로그인 하러 가기"
-        handleBtnClick={() => {
-          navigate('/login');
-        }}>
+        handleBtnClick={googleLogin}>
         <AlreadyModalView />
       </BtnCloseModal>
     </Wrapper>

--- a/src/pages/onboarding/components/commonOnboarding/Step학과선택.tsx
+++ b/src/pages/onboarding/components/commonOnboarding/Step학과선택.tsx
@@ -47,14 +47,13 @@ const Step학과선택 = () => {
         },
         {
           onSuccess: () => {
-            navigate('/juniorOnboardingComplete');
+            navigate('/juniorOnboarding/complete');
           },
           onError: (err) => {
             console.log(err);
           },
-        },
+        }
       );
-      alert('온보딩 끝!');
     }
   };
 


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #254 
Closes #255 

> **단순히 잘못된 route를 사용중이던 navigate path 값을 수정해준 작업이라 가볍게 보셔도 됩니다!** 


## ✅ Done Task
  - [x] 번호입력 뷰 - 이미 가입된 번호 모달 - 로그인 하러 가기 버튼 클릭 시 오류 수정 
  - [x] 후배 온보딩 완료 시 alert 제거 및 정상 navigate되도록 수정 


## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->
1. 이미 가입된 번호 모달 - 로그인하러 가기 버튼 클릭 시 기존에는 존재하지 않는 Path로 이동해서 404가 터졌었는데요, 
곧바로 구글 로그인 페이지로 이동하도록 수정했습니다. 

2. 후배 온보딩 완료 시 alert가 뜨고, alert 확인을 누르면 404가 터졌었는데요, 불필요한 alert를 삭제했고 온보딩 완료 시 정상적인 path (/juniorOnboarding/complete) 로 이동할 수 있도록 수정해주었습니다. 

## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->

1번

https://github.com/user-attachments/assets/d0a5f619-2dfe-43dc-920f-efa328a56170

2번 

2번은 지금 가입할 수 있는 학생 이메일이 없어서 인증샷 생략합니다 , , 