### PR TITLE
[ Fix ] junior promise 렌더링 에러 해결

### DIFF
--- a/src/pages/juniorPromise/JuniorPromisePage.tsx
+++ b/src/pages/juniorPromise/JuniorPromisePage.tsx
@@ -19,7 +19,6 @@ import useSeniorProfileQueries from '@hooks/seniorProfileQueries';
 const JuniorPromisePage = () => {
   const navigate = useNavigate();
 
-  // 1. 모든 상태 훅을 컴포넌트 최상단에 배치
   // 바텀 시트 내 버튼& 내용 필터 버튼
   const [filterActiveBtn, setFilterActiveBtn] = useState('계열');
   // 바텀 시트 여는 동작
@@ -32,11 +31,9 @@ const JuniorPromisePage = () => {
   const [seniorId, setSeniorId] = useState(0);
   const [seniorNickname, setSeniorNickname] = useState('');
 
-  // 2. useQuery 호출을 조건부 렌더링 밖으로 이동
   // 쿼리 사용하여 데이터 가져오기
   const { data, isLoading, isError } = useSeniorProfileQueries(chipFieldName, chipPositionName);
 
-  // 3. 핸들러 함수들을 상단에 정의
   // 필터 버튼에 정보 넣기, 바텀시트 열기
   const handleFilterActiveBtn = (btnText: string) => {
     setFilterActiveBtn(btnText);
@@ -119,15 +116,12 @@ const JuniorPromisePage = () => {
     });
   };
 
-  // 4. 로딩과 에러 상태 처리
   if (isLoading) return <Loading />;
   if (isError) return <ErrorPage />;
 
-  // 5. 데이터 처리
   const seniorList = data?.data.seniorList || [];
   const myNickname = data?.data.myNickname;
 
-  // 6. 공통 props 객체
   const SeniorSearchCommonProps = {
     handleFilterActiveBtn,
     handleReset,

--- a/src/pages/juniorPromise/JuniorPromisePage.tsx
+++ b/src/pages/juniorPromise/JuniorPromisePage.tsx
@@ -21,6 +21,7 @@ const JuniorPromisePage = () => {
   const navigate = useNavigate();
 
   // 바텀 시트 내 버튼& 내용 필터 버튼
+  // 1. 모든 상태 훅을 컴포넌트 최상단에 배치
   const [filterActiveBtn, setFilterActiveBtn] = useState('계열');
   const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
   const [chipFieldName, setChipFieldName] = useState<string[]>([]);
@@ -29,9 +30,11 @@ const JuniorPromisePage = () => {
   const [seniorId, setSeniorId] = useState(0);
   const [seniorNickname, setSeniorNickname] = useState('');
 
+  // 2. useQuery 호출을 조건부 렌더링 밖으로 이동
   const { data, isLoading, isError } = useSeniorProfileQueries(chipFieldName, chipPositionName);
 
   // 필터 버튼에 정보 넣기, 바텀시트 열기
+  // 3. 핸들러 함수들을 상단에 정의
   const handleFilterActiveBtn = (btnText: string) => {
     setFilterActiveBtn(btnText);
     setIsBottomSheetOpen(true);
@@ -57,12 +60,15 @@ const JuniorPromisePage = () => {
     });
   };
 
+  // 4. 로딩과 에러 상태 처리
   if (isLoading) return <Loading />;
   if (isError) return <ErrorPage />;
 
+  // 5. 데이터 처리
   const seniorList = data?.data.seniorList || [];
   const myNickname = data?.data.myNickname;
 
+  // 6. 공통 props 객체
   const seniorSearchCommonProps = {
     handleFilterActiveBtn,
     handleReset,

--- a/src/pages/juniorPromise/JuniorPromisePage.tsx
+++ b/src/pages/juniorPromise/JuniorPromisePage.tsx
@@ -7,7 +7,6 @@ import { BottomSheet } from '@pages/juniorPromise/components/BottomSheet';
 import { useState } from 'react';
 import { SeniorSearch } from './components/SeniorSearch';
 
-import seniorProfileQueries from '../../hooks/seniorProfileQueries';
 import PreView from '@pages/seniorProfile/components/preView';
 import { FullBtn } from '@components/commons/FullButton';
 import Loading from '@components/commons/Loading';
@@ -15,26 +14,30 @@ import ErrorPage from '@pages/errorPage/ErrorPage';
 
 import { Banner } from './components/seniorFilter/Banner';
 import { useNavigate } from 'react-router-dom';
-import useSeniorProfileQueries from '../../hooks/seniorProfileQueries';
+import useSeniorProfileQueries from '@hooks/seniorProfileQueries';
 
 const JuniorPromisePage = () => {
   const navigate = useNavigate();
 
-  // 바텀 시트 내 버튼& 내용 필터 버튼
   // 1. 모든 상태 훅을 컴포넌트 최상단에 배치
+  // 바텀 시트 내 버튼& 내용 필터 버튼
   const [filterActiveBtn, setFilterActiveBtn] = useState('계열');
+  // 바텀 시트 여는 동작
   const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
+  // 칩으로 나갈 선택된 계열 이름 리스트
   const [chipFieldName, setChipFieldName] = useState<string[]>([]);
+  // 칩으로 나갈 선택된 직무 리스트
   const [chipPositionName, setChipPositionName] = useState<string[]>([]);
   const [isSeniorCardClicked, setIsSeniorCardClicked] = useState(false);
   const [seniorId, setSeniorId] = useState(0);
   const [seniorNickname, setSeniorNickname] = useState('');
 
   // 2. useQuery 호출을 조건부 렌더링 밖으로 이동
+  // 쿼리 사용하여 데이터 가져오기
   const { data, isLoading, isError } = useSeniorProfileQueries(chipFieldName, chipPositionName);
 
-  // 필터 버튼에 정보 넣기, 바텀시트 열기
   // 3. 핸들러 함수들을 상단에 정의
+  // 필터 버튼에 정보 넣기, 바텀시트 열기
   const handleFilterActiveBtn = (btnText: string) => {
     setFilterActiveBtn(btnText);
     setIsBottomSheetOpen(true);
@@ -44,7 +47,63 @@ const JuniorPromisePage = () => {
     setChipFieldName([]);
     setChipPositionName([]);
   };
+  // 선택 계열 리스트 배열로
+  const isFieldSelected = (fieldName: string) => chipFieldName.includes(fieldName);
 
+  const handleChipField = (fieldName: string) => {
+    if (isFieldSelected(fieldName)) {
+      setChipFieldName((prev) => prev.filter((name) => name !== fieldName));
+    } else {
+      setChipFieldName((prev) => [...prev, fieldName]);
+    }
+  };
+  // 선택 직무 리스트
+  const isPositionSelected = (positionName: string) => chipPositionName.includes(positionName);
+
+  const handleChipPosition = (positionName: string) => {
+    if (isPositionSelected(positionName)) {
+      setChipPositionName((prev) => prev.filter((name) => name !== positionName));
+    } else {
+      setChipPositionName((prev) => [...prev, positionName]);
+    }
+  };
+
+  // S- 계열리스트에 이름빼는 함수
+  const deleteFieldList = (chipName: string) => {
+    setChipFieldName((prev) => prev.filter((name) => name !== chipName));
+  };
+
+  // S- 직무리스트에 이름 빼는 함수
+  const deletePositionList = (chipName: string) => {
+    setChipPositionName((prev) => prev.filter((name) => name !== chipName));
+  };
+
+  // B- 계열리스트에 이름넣는 함수
+  const pushFieldList = (chipName: string) => {
+    setChipFieldName((prev) => {
+      if (prev.indexOf(chipName) === -1) {
+        return [...prev, chipName];
+      } else {
+        return prev.filter((name) => name !== chipName);
+      }
+    });
+  };
+
+  // B- 직무리스트에 이름 넣는 함수
+  const pushPositionList = (chipName: string) => {
+    setChipPositionName((prev) => {
+      if (prev.indexOf(chipName) === -1) {
+        return [...prev, chipName];
+      } else {
+        return prev.filter((name) => name !== chipName);
+      }
+    });
+  };
+
+  // B- 바텀시트 닫기
+  const handleCloseBottomSheet = () => {
+    setIsBottomSheetOpen(false);
+  };
   const handleSeniorCardClicked = (type: boolean, id: number, name: string) => {
     setIsSeniorCardClicked(type);
     setSeniorId(id);
@@ -69,29 +128,26 @@ const JuniorPromisePage = () => {
   const myNickname = data?.data.myNickname;
 
   // 6. 공통 props 객체
-  const seniorSearchCommonProps = {
+  const SeniorSearchCommonProps = {
     handleFilterActiveBtn,
     handleReset,
     chipPositionName,
     chipFieldName,
-    handleChipField: (fieldName: string) => {
-      setChipFieldName((prev) =>
-        prev.includes(fieldName) ? prev.filter((name) => name !== fieldName) : [...prev, fieldName]
-      );
-    },
-    handleChipPosition: (positionName: string) => {
-      setChipPositionName((prev) =>
-        prev.includes(positionName) ? prev.filter((name) => name !== positionName) : [...prev, positionName]
-      );
-    },
+    handleChipField,
+    handleChipPosition,
   };
 
   return (
     <>
       {isSeniorCardClicked ? (
         <>
-          <Header LeftSvg={ArrowLeftIc} onClickLeft={() => setIsSeniorCardClicked(false)} />
-          <PreView variant="secondary" seniorId={String(seniorId)} />
+          <Header
+            LeftSvg={ArrowLeftIc}
+            onClickLeft={() => {
+              setIsSeniorCardClicked(false);
+            }}
+          />
+          <PreView variant="secondary" seniorId={seniorId + ''} />
           <FullBtn text="약속 신청하기" onClick={handlePromiseClicked} />
         </>
       ) : (
@@ -99,36 +155,18 @@ const JuniorPromisePage = () => {
           <Banner myNickname={myNickname} />
           <ContentWrapper>
             <SeniorSearch
-              {...seniorSearchCommonProps}
-              deleteFieldList={(chipName: string) =>
-                setChipFieldName((prev) => prev.filter((name) => name !== chipName))
-              }
-              deletePositionList={(chipName: string) =>
-                setChipPositionName((prev) => prev.filter((name) => name !== chipName))
-              }
+              {...SeniorSearchCommonProps}
+              deleteFieldList={deleteFieldList}
+              deletePositionList={deletePositionList}
               $chipFieldName={chipFieldName}
               $chipPositionName={chipPositionName}>
               <BottomSheet
-                {...seniorSearchCommonProps}
+                {...SeniorSearchCommonProps}
                 filterActiveBtn={filterActiveBtn}
-                handleCloseBottomSheet={() => setIsBottomSheetOpen(false)}
+                handleCloseBottomSheet={handleCloseBottomSheet}
                 isBottomSheetOpen={isBottomSheetOpen}
-                pushFieldList={(chipName: string) => {
-                  setChipFieldName((prev) => {
-                    if (prev.includes(chipName)) {
-                      return prev.filter((name) => name !== chipName);
-                    }
-                    return [...prev, chipName];
-                  });
-                }}
-                pushPositionList={(chipName: string) => {
-                  setChipPositionName((prev) => {
-                    if (prev.includes(chipName)) {
-                      return prev.filter((name) => name !== chipName);
-                    }
-                    return [...prev, chipName];
-                  });
-                }}
+                pushFieldList={pushFieldList}
+                pushPositionList={pushPositionList}
               />
             </SeniorSearch>
             <SeniorCardListLayout>


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #263

## ✅ Done Task

- [x] JuniorPromise 코드 순서 재배치

## ☀️ New-insight
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->
![KakaoTalk_Photo_2024-10-01-17-36-02](https://github.com/user-attachments/assets/e98657a8-47a0-447f-93a3-73924f94fa00)


`React Router caught the following error during render Error: Rendered more hooks than during the previous render.
`
이 에러는 이전 렌더링과 비교해서 현재 렌더링에서 더 많은 훅이 사용되었다는 것을 알려주는 것이라고 합니다!!
조건부로 훅을 호출하면 이런 에러가 발생할 수 있고, React에서 훅은 항상 동일한 순서로 호출되어야 한다고 하네요 

☀️ 아래 방법들로 해결할 수 있슴다~!
1. 모든 useState 훅을 컴포넌트 최상단으로 이동
2. 조건부 반환 (if (isLoading), if (isError))을 모든 훅 선언 이후로 이동
3. 데이터 처리 로직을 단순화하고 일관성 있게 배치


## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->

JuniorPromise 컴포넌트를 다음과 같이 재구성 하였습니다.

1. 모든 `useState` 상태 훅을 컴포넌트 최상단에 배치
2. `useSeniorProfileQueries` 호출을 조건부 렌더링 밖으로 이동
3. 모든 이벤트 핸들러와 상태 업데이트 함수를 상단에 정의


따라서 모든 훅이 일관된 순서로 호출되고, 조건부 렌더링이 훅의 호출에 영향을 미치지 않기 때문에 해결할 수 있습니다


## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->
해결 완료!!

https://github.com/user-attachments/assets/1d01cc0c-77f9-468e-94ff-3d4e89e49102

