### PR TITLE
[ Refactor ] junior propmise page isBottomSheetOpen프롭스 제거

### DIFF
--- a/src/components/commons/ToggleButton.tsx
+++ b/src/components/commons/ToggleButton.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 interface toggleButtonPropType {
   left: string;
   right: string;
-  activeButton: string;
+  activeButton: string | null;
   onSetActiveButtonHandler: (button: string) => void;
 }
 

--- a/src/pages/juniorPromise/JuniorPromisePage.tsx
+++ b/src/pages/juniorPromise/JuniorPromisePage.tsx
@@ -7,7 +7,6 @@ import { BottomSheet } from '@pages/juniorPromise/components/BottomSheet';
 import { useState } from 'react';
 import { SeniorSearch } from './components/SeniorSearch';
 
-import seniorProfileQueries from '../../hooks/seniorProfileQueries';
 import PreView from '@pages/seniorProfile/components/preView';
 import { FullBtn } from '@components/commons/FullButton';
 import Loading from '@components/commons/Loading';
@@ -15,6 +14,7 @@ import ErrorPage from '@pages/errorPage/ErrorPage';
 
 import { Banner } from './components/seniorFilter/Banner';
 import { useNavigate } from 'react-router-dom';
+import useSeniorProfileQueries from '@hooks/seniorProfileQueries';
 
 const JuniorPromisePage = () => {
   const navigate = useNavigate();
@@ -23,6 +23,16 @@ const JuniorPromisePage = () => {
   const [filterActiveBtn, setFilterActiveBtn] = useState('계열');
   // 바텀 시트 여는 동작
   const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
+  // 칩으로 나갈 선택된 계열 이름 리스트
+  const [chipFieldName, setChipFieldName] = useState<string[]>([]);
+  // 칩으로 나갈 선택된 직무 리스트
+  const [chipPositionName, setChipPositionName] = useState<string[]>([]);
+  const [isSeniorCardClicked, setIsSeniorCardClicked] = useState(false);
+  const [seniorId, setSeniorId] = useState(0);
+  const [seniorNickname, setSeniorNickname] = useState('');
+
+  // 쿼리 사용하여 데이터 가져오기
+  const { data, isLoading, isError } = useSeniorProfileQueries(chipFieldName, chipPositionName);
 
   // 필터 버튼에 정보 넣기, 바텀시트 열기
   const handleFilterActiveBtn = (btnText: string) => {
@@ -34,13 +44,6 @@ const JuniorPromisePage = () => {
     setChipFieldName([]);
     setChipPositionName([]);
   };
-
-  // 칩으로 나갈 선택된 계열 이름 리스트
-  const [chipFieldName, setChipFieldName] = useState<string[]>([]);
-
-  // 칩으로 나갈 선택된 직무 리스트
-  const [chipPositionName, setChipPositionName] = useState<string[]>([]);
-
   // 선택 계열 리스트 배열로
   const isFieldSelected = (fieldName: string) => chipFieldName.includes(fieldName);
 
@@ -51,7 +54,6 @@ const JuniorPromisePage = () => {
       setChipFieldName((prev) => [...prev, fieldName]);
     }
   };
-
   // 선택 직무 리스트
   const isPositionSelected = (positionName: string) => chipPositionName.includes(positionName);
 
@@ -61,15 +63,6 @@ const JuniorPromisePage = () => {
     } else {
       setChipPositionName((prev) => [...prev, positionName]);
     }
-  };
-
-  const SeniorSearchCommonProps = {
-    handleFilterActiveBtn,
-    handleReset,
-    chipPositionName,
-    chipFieldName,
-    handleChipField,
-    handleChipPosition,
   };
 
   // S- 계열리스트에 이름빼는 함수
@@ -108,26 +101,12 @@ const JuniorPromisePage = () => {
   const handleCloseBottomSheet = () => {
     setIsBottomSheetOpen(false);
   };
-
-  // 쿼리 사용하여 데이터 가져오기
-  const { data, isLoading, isError } = seniorProfileQueries(chipFieldName, chipPositionName);
-  const seniorList = data?.data.seniorList || [];
-  const myNickname = data?.data.myNickname;
-  if (isLoading) {
-    return <Loading />;
-  }
-  if (isError) {
-    return <ErrorPage />;
-  }
-
-  const [isSeniorCardClicked, setIsSeniorCardClicked] = useState(false);
-  const [seniorId, setSeniorId] = useState(0);
-  const [seniorNickname, setSeniorNickname] = useState('');
   const handleSeniorCardClicked = (type: boolean, id: number, name: string) => {
     setIsSeniorCardClicked(type);
     setSeniorId(id);
     setSeniorNickname(name);
   };
+
   const handlePromiseClicked = () => {
     navigate('/juniorPromiseRequest', {
       state: {
@@ -135,6 +114,21 @@ const JuniorPromisePage = () => {
         seniorNickname,
       },
     });
+  };
+
+  if (isLoading) return <Loading />;
+  if (isError) return <ErrorPage />;
+
+  const seniorList = data?.data.seniorList || [];
+  const myNickname = data?.data.myNickname;
+
+  const SeniorSearchCommonProps = {
+    handleFilterActiveBtn,
+    handleReset,
+    chipPositionName,
+    chipFieldName,
+    handleChipField,
+    handleChipPosition,
   };
 
   return (

--- a/src/pages/juniorPromise/JuniorPromisePage.tsx
+++ b/src/pages/juniorPromise/JuniorPromisePage.tsx
@@ -72,28 +72,6 @@ const JuniorPromisePage = () => {
     setChipPositionName((prev) => prev.filter((name) => name !== chipName));
   };
 
-  // B- 계열리스트에 이름넣는 함수
-  const pushFieldList = (chipName: string) => {
-    setChipFieldName((prev) => {
-      if (prev.indexOf(chipName) === -1) {
-        return [...prev, chipName];
-      } else {
-        return prev.filter((name) => name !== chipName);
-      }
-    });
-  };
-
-  // B- 직무리스트에 이름 넣는 함수
-  const pushPositionList = (chipName: string) => {
-    setChipPositionName((prev) => {
-      if (prev.indexOf(chipName) === -1) {
-        return [...prev, chipName];
-      } else {
-        return prev.filter((name) => name !== chipName);
-      }
-    });
-  };
-
   // B- 바텀시트 닫기
   const handleCloseBottomSheet = () => {
     setFilterActiveBtn(null);
@@ -155,8 +133,6 @@ const JuniorPromisePage = () => {
                 {...SeniorSearchCommonProps}
                 filterActiveBtn={filterActiveBtn}
                 handleCloseBottomSheet={handleCloseBottomSheet}
-                pushFieldList={pushFieldList}
-                pushPositionList={pushPositionList}
               />
             </SeniorSearch>
             <SeniorCardListLayout>

--- a/src/pages/juniorPromise/JuniorPromisePage.tsx
+++ b/src/pages/juniorPromise/JuniorPromisePage.tsx
@@ -20,9 +20,7 @@ const JuniorPromisePage = () => {
   const navigate = useNavigate();
 
   // 바텀 시트 내 버튼& 내용 필터 버튼
-  const [filterActiveBtn, setFilterActiveBtn] = useState('계열');
-  // 바텀 시트 여는 동작
-  const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
+  const [filterActiveBtn, setFilterActiveBtn] = useState<string | null>(null);
   // 칩으로 나갈 선택된 계열 이름 리스트
   const [chipFieldName, setChipFieldName] = useState<string[]>([]);
   // 칩으로 나갈 선택된 직무 리스트
@@ -37,14 +35,13 @@ const JuniorPromisePage = () => {
   // 필터 버튼에 정보 넣기, 바텀시트 열기
   const handleFilterActiveBtn = (btnText: string) => {
     setFilterActiveBtn(btnText);
-    setIsBottomSheetOpen(true);
   };
   // 초기화 함수
   const handleReset = () => {
     setChipFieldName([]);
     setChipPositionName([]);
   };
-  // 선택 계열 리스트 배열로
+  // 선택 계열 리스트
   const isFieldSelected = (fieldName: string) => chipFieldName.includes(fieldName);
 
   const handleChipField = (fieldName: string) => {
@@ -99,7 +96,7 @@ const JuniorPromisePage = () => {
 
   // B- 바텀시트 닫기
   const handleCloseBottomSheet = () => {
-    setIsBottomSheetOpen(false);
+    setFilterActiveBtn(null);
   };
   const handleSeniorCardClicked = (type: boolean, id: number, name: string) => {
     setIsSeniorCardClicked(type);
@@ -145,7 +142,7 @@ const JuniorPromisePage = () => {
           <FullBtn text="약속 신청하기" onClick={handlePromiseClicked} />
         </>
       ) : (
-        <PreventScroll $isBottomSheetOpen={isBottomSheetOpen}>
+        <PreventScroll $filterActiveBtn={filterActiveBtn}>
           <Banner myNickname={myNickname} />
           <ContentWrapper>
             <SeniorSearch
@@ -158,7 +155,6 @@ const JuniorPromisePage = () => {
                 {...SeniorSearchCommonProps}
                 filterActiveBtn={filterActiveBtn}
                 handleCloseBottomSheet={handleCloseBottomSheet}
-                isBottomSheetOpen={isBottomSheetOpen}
                 pushFieldList={pushFieldList}
                 pushPositionList={pushPositionList}
               />
@@ -183,8 +179,8 @@ const JuniorPromisePage = () => {
 
 export default JuniorPromisePage;
 
-const PreventScroll = styled.div<{ $isBottomSheetOpen: boolean }>`
-  position: ${({ $isBottomSheetOpen }) => ($isBottomSheetOpen ? 'fixed' : 'relative')};
+const PreventScroll = styled.div<{ $filterActiveBtn: string | null }>`
+  position: ${({ $filterActiveBtn }) => ($filterActiveBtn !== null ? 'fixed' : 'relative')};
 
   width: 100%;
   height: 100vh;

--- a/src/pages/juniorPromise/components/BottomSheet.tsx
+++ b/src/pages/juniorPromise/components/BottomSheet.tsx
@@ -7,9 +7,8 @@ import { FIELD_LIST } from '../constants/fieldList';
 import { POSITION_LIST } from '../constants/positionList';
 
 interface BottomSheetPropTypes {
-  filterActiveBtn: string;
+  filterActiveBtn: string | null;
   handleFilterActiveBtn: (btnText: string) => void;
-  isBottomSheetOpen: boolean;
   handleCloseBottomSheet: () => void;
   handleChipPosition: (positionName: string) => void;
   handleChipField: (fieldName: string) => void;
@@ -32,7 +31,6 @@ export const BottomSheet = (props: BottomSheetPropTypes) => {
     chipPositionName,
     filterActiveBtn,
     handleFilterActiveBtn,
-    isBottomSheetOpen,
     handleCloseBottomSheet,
     handleChipPosition,
     handleChipField,
@@ -41,8 +39,8 @@ export const BottomSheet = (props: BottomSheetPropTypes) => {
 
   return (
     <>
-      <Background $isBottomSheetOpen={isBottomSheetOpen} onClick={handleCloseBottomSheet} />
-      <BottomSheetWrapper $isBottomSheetOpen={isBottomSheetOpen}>
+      <Background $filterActiveBtn={filterActiveBtn} onClick={handleCloseBottomSheet} />
+      <BottomSheetWrapper $filterActiveBtn={filterActiveBtn}>
         <LineBox>
           <Line />
         </LineBox>
@@ -101,8 +99,8 @@ export const BottomSheet = (props: BottomSheetPropTypes) => {
   );
 };
 
-const Background = styled.div<{ $isBottomSheetOpen: boolean }>`
-  display: ${({ $isBottomSheetOpen }) => ($isBottomSheetOpen ? 'flex' : 'none')};
+const Background = styled.div<{ $filterActiveBtn: string | null }>`
+  display: ${({ $filterActiveBtn }) => ($filterActiveBtn === null ? 'none' : 'flex')};
   position: fixed;
   top: 0;
   z-index: 2;
@@ -113,7 +111,7 @@ const Background = styled.div<{ $isBottomSheetOpen: boolean }>`
   background: ${({ theme }) => theme.colors.transparentBlack_65};
 `;
 
-const BottomSheetWrapper = styled.form<{ $isBottomSheetOpen: boolean }>`
+const BottomSheetWrapper = styled.form<{ $filterActiveBtn: string | null }>`
   display: flex;
   flex-direction: column;
   position: fixed;
@@ -126,8 +124,8 @@ const BottomSheetWrapper = styled.form<{ $isBottomSheetOpen: boolean }>`
 
   background: ${({ theme }) => theme.colors.grayScaleWhite};
 
-  opacity: ${({ $isBottomSheetOpen }) => ($isBottomSheetOpen ? 1 : 0)};
-  transform: translateY(${({ $isBottomSheetOpen }) => ($isBottomSheetOpen ? '0' : '100%')});
+  opacity: ${({ $filterActiveBtn }) => ($filterActiveBtn === null ? 0 : 1)};
+  transform: translateY(${({ $filterActiveBtn }) => ($filterActiveBtn === null ? '100%' : '0')});
 
   transition:
     transform 250ms ease-in-out,

--- a/src/pages/juniorPromise/components/BottomSheet.tsx
+++ b/src/pages/juniorPromise/components/BottomSheet.tsx
@@ -15,9 +15,7 @@ interface BottomSheetPropTypes {
 
   handleReset: () => void;
   chipFieldName: string[];
-  pushFieldList: (chipName: string) => void;
   chipPositionName: string[];
-  pushPositionList: (chipName: string) => void;
 }
 
 interface SelectedChipListProps {


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #244 

## ✅ Done Task
  - [x] `isBottomSheetOpen` 프롭스 제거
  - [x] 관련 로직 수정
  - [x] 불필요한 함수 제거

## ☀️ New-insight
.

## 💎 PR Point
📣 feat~ 타입변경 커밋부터 확인해주시면 됩니다..!

1️⃣ `isBottomSheetOpen` 상태 제거
: 바텀시트를 열고 닫는 것을 관장하던 상태 제거

2️⃣ 공통 토글 버튼 타입 변경
: 담당자였던 지은이의 허락을 받고 변경했습니다..! 변경했을 때 별다른 오류는 없었습니다.
```
interface toggleButtonPropType {
  left: string;
  right: string;
  activeButton: string | null;
  onSetActiveButtonHandler: (button: string) => void;
}
```
activeButton에 null 을 추가해 
string일때는 string 내용에 맞는 바텀시트가 열리고(계열, 직무) 
null일때는 닫히도록 구현하였습니다.

3️⃣ 해당 로직을 `filterActiveBtn` 를 활용해 변경  
`const [filterActiveBtn, setFilterActiveBtn] = useState<string | null>(null);
`
: 기존 isBottomSheetOpen을 활용했던 로직을 위의 상태를 이용해 모두 변경했습니다!

4️⃣ 이전 리팩토링 과정에서 해당로직을 handleChipField, handleChipPosition으로 수정했는데 기존의 사용하던 함수를 지우지 않았더라구요,, 미사용 함수 제거 했습니다..!


## 📸 Screenshot
변경 이후 에러 없는 화면입니다!


https://github.com/user-attachments/assets/93676735-6576-450f-9586-967077dd50c0

