### PR TITLE
[ Fix ] 약속리스트 변경된 라우터 반영 / 이전탭 남아있도록 수정

### DIFF
--- a/src/pages/promiseDetail/PromiseDetailPage.tsx
+++ b/src/pages/promiseDetail/PromiseDetailPage.tsx
@@ -285,11 +285,11 @@ const PromiseDetail = () => {
       </Wrapper>
 
       {viewType === 'DECLINE' ? (
-        <AutoCloseModal text="선약이 거절되었어요" showModal={isModalOpen} handleShowModal={handleModalOpen} path="/">
+        <AutoCloseModal text="선약이 거절되었어요" showModal={isModalOpen} handleShowModal={handleModalOpen} path="/promiseList">
           <ModalRejectImg />
         </AutoCloseModal>
       ) : (
-        <AutoCloseModal text="선약이 수락되었어요" showModal={isModalOpen} handleShowModal={handleModalOpen} path="/">
+        <AutoCloseModal text="선약이 수락되었어요" showModal={isModalOpen} handleShowModal={handleModalOpen} path="/promiseList">
           <ModalAcceptImg />
         </AutoCloseModal>
       )}

--- a/src/pages/promiseDetail/PromiseDetailPage.tsx
+++ b/src/pages/promiseDetail/PromiseDetailPage.tsx
@@ -153,7 +153,11 @@ const PromiseDetail = () => {
     <>
       <Header
         LeftSvg={ArrowLeftIc}
-        onClickLeft={() => navigate('/promiseList')}
+        onClickLeft={() => navigate(`/promiseList`, {
+          state: {
+            prevTap: tap
+          }
+        })}
         title={viewType === 'DEFAULT' ? '자세히 보기' : '거절하기'}
       />
       <hr />

--- a/src/pages/promiseDetail/PromiseDetailPageJunior.tsx
+++ b/src/pages/promiseDetail/PromiseDetailPageJunior.tsx
@@ -63,7 +63,17 @@ const PromiseDetailPageJunior = () => {
         </>
       ) : (
         <>
-          <Header LeftSvg={ArrowLeftIc} title="자세히 보기" onClickLeft={() => navigate('/promiseList')} />
+          <Header
+            LeftSvg={ArrowLeftIc}
+            title="자세히 보기"
+            onClickLeft={() =>
+              navigate(`/promiseList`, {
+                state: {
+                  prevTap: tap,
+                },
+              })
+            }
+          />
           <Wrapper>
             <Layout>
               <TitleContainer>

--- a/src/pages/promiseList/components/ProfileContainer.tsx
+++ b/src/pages/promiseList/components/ProfileContainer.tsx
@@ -54,7 +54,7 @@ const ProfileContainer = (props: ProfileContainerPropType) => {
       });
     }
     if (userRole === 'JUNIOR' && tap === 'pending') {
-      navigate('./promiseList/promiseDetailJunior', {
+      navigate('/promiseList/promiseDetailJunior', {
         state: {
           tap: 'pending',
           myNickname,
@@ -65,13 +65,13 @@ const ProfileContainer = (props: ProfileContainerPropType) => {
     }
 
     if (userRole === 'SENIOR' && (tap === 'scheduled' || tap === 'default') && detail !== 'detail') {
-      navigate('./promiseList/promiseDetail', {
+      navigate('/promiseList/promiseDetail', {
         state: { tap: 'scheduled', myNickname: myNickname, appointmentId: profileCardData?.appointmentId },
       });
     }
 
     if (userRole === 'JUNIOR' && (tap === 'scheduled' || tap === 'default') && detail !== 'detail') {
-      navigate('./promiseList/promiseDetailJunior', {
+      navigate('/promiseList/promiseDetailJunior', {
         state: {
           tap: 'scheduled',
           myNickname: myNickname,

--- a/src/pages/promiseList/components/ProfileContainer.tsx
+++ b/src/pages/promiseList/components/ProfileContainer.tsx
@@ -49,12 +49,12 @@ const ProfileContainer = (props: ProfileContainerPropType) => {
   // 상세 페이지 라우팅
   const handleClickProfileContainer = (tap: string, userRole: string) => {
     if (userRole === 'SENIOR' && tap === 'pending') {
-      navigate('/promiseDetail', {
+      navigate('/promiseList/promiseDetail', {
         state: { tap: 'pending', myNickname: myNickname, appointmentId: profileCardData?.appointmentId },
       });
     }
     if (userRole === 'JUNIOR' && tap === 'pending') {
-      navigate('./promiseDetailJunior', {
+      navigate('./promiseList/promiseDetailJunior', {
         state: {
           tap: 'pending',
           myNickname,
@@ -65,13 +65,13 @@ const ProfileContainer = (props: ProfileContainerPropType) => {
     }
 
     if (userRole === 'SENIOR' && (tap === 'scheduled' || tap === 'default') && detail !== 'detail') {
-      navigate('./promiseDetail', {
+      navigate('./promiseList/promiseDetail', {
         state: { tap: 'scheduled', myNickname: myNickname, appointmentId: profileCardData?.appointmentId },
       });
     }
 
     if (userRole === 'JUNIOR' && (tap === 'scheduled' || tap === 'default') && detail !== 'detail') {
-      navigate('./promiseDetailJunior', {
+      navigate('./promiseList/promiseDetailJunior', {
         state: {
           tap: 'scheduled',
           myNickname: myNickname,

--- a/src/pages/promiseList/components/PromiseTap.tsx
+++ b/src/pages/promiseList/components/PromiseTap.tsx
@@ -27,7 +27,7 @@ const PromiseTap = (props: PromiseTapPropType) => {
       setTap(prevTap);
       navigate(location.pathname, { state: '' });
     }
-  }, []);
+  }, [prevTap]);
 
   const getTapContent = (tap: string) => {
     switch (tap) {

--- a/src/pages/promiseList/components/PromiseTap.tsx
+++ b/src/pages/promiseList/components/PromiseTap.tsx
@@ -4,7 +4,7 @@ import ProfileContainer from './ProfileContainer';
 import { PROMISE_TAP } from '../constants/constants';
 import { profileCardDataType } from '../types/type';
 import { getEmptyMessage } from '../utils/getEmptyMessage';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 interface PromiseTapPropType {
   userRole: string;
@@ -16,6 +16,7 @@ interface PromiseTapPropType {
 
 const PromiseTap = (props: PromiseTapPropType) => {
   const location = useLocation();
+  const navigate = useNavigate();
   const [tap, setTap] = useState('pending');
   const { userRole, pending, scheduled, past, myNickname } = props;
 
@@ -24,8 +25,9 @@ const PromiseTap = (props: PromiseTapPropType) => {
   useEffect(() => {
     if (prevTap && Object.keys(prevTap).length !== 0) {
       setTap(prevTap);
+      navigate(location.pathname, { state: '' });
     }
-  }, [prevTap]);
+  }, []);
 
   const getTapContent = (tap: string) => {
     switch (tap) {

--- a/src/pages/promiseList/components/PromiseTap.tsx
+++ b/src/pages/promiseList/components/PromiseTap.tsx
@@ -1,9 +1,10 @@
 import styled from '@emotion/styled';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import ProfileContainer from './ProfileContainer';
 import { PROMISE_TAP } from '../constants/constants';
 import { profileCardDataType } from '../types/type';
 import { getEmptyMessage } from '../utils/getEmptyMessage';
+import { useLocation } from 'react-router-dom';
 
 interface PromiseTapPropType {
   userRole: string;
@@ -14,8 +15,17 @@ interface PromiseTapPropType {
 }
 
 const PromiseTap = (props: PromiseTapPropType) => {
+  const location = useLocation();
   const [tap, setTap] = useState('pending');
   const { userRole, pending, scheduled, past, myNickname } = props;
+
+  const { prevTap } = location.state || {};
+
+  useEffect(() => {
+    if (prevTap && Object.keys(prevTap).length !== 0) {
+      setTap(prevTap);
+    }
+  }, [prevTap]);
 
   const getTapContent = (tap: string) => {
     switch (tap) {
@@ -30,7 +40,6 @@ const PromiseTap = (props: PromiseTapPropType) => {
     }
   };
 
-  console.log(scheduled);
   return (
     <Wrapper>
       <TapContainer>


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #267 

## ✅ Done Task
  - [x] 약속리스트 변경된 라우터 (/ -> promiseList) 반영
  - [x] 뒤로가기 했을 경우 확정대기/예정약속/지난약속 이전 탭 반영

## ☀️ New-insight
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->
없

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->
- 약속 디테일 페이지에 들어갔다가 뒤로가기 하면 매번 확정대기 탭으로 이동되던 이슈가 있었는데, 사용자가 이전에 남아있던 탭 기억해서 반영하도록 작업해두었습니다.

- `약속 리스트 페이지`에서 약속 컨테이너 클릭시, 어느 탭에서 눌린 건지 navigate의 state로 전달하는 로직이 있습니다.
```typescript
// ProfileContainer.tsx

// 상세 페이지 라우팅
  const handleClickProfileContainer = (tap: string, userRole: string) => {
    if (userRole === 'SENIOR' && tap === 'pending') {
      navigate('/promiseList/promiseDetail', {
        // ✅✅✅ 요부분!! ✅✅✅
        state: { tap: 'pending', myNickname: myNickname, appointmentId: profileCardData?.appointmentId },
      });
    }
    if (userRole === 'JUNIOR' && tap === 'pending') {
      navigate('/promiseList/promiseDetailJunior', {
        // ✅✅✅ 요부분!! ✅✅✅
        state: {
          tap: 'pending',
          myNickname,
          appointmentId: profileCardData?.appointmentId,
          seniorId: profileCardData?.seniorId,
        },
      });
    }

    if (userRole === 'SENIOR' && (tap === 'scheduled' || tap === 'default') && detail !== 'detail') {
      navigate('/promiseList/promiseDetail', {
        // ✅✅✅ 요부분!! ✅✅✅
        state: { tap: 'scheduled', myNickname: myNickname, appointmentId: profileCardData?.appointmentId },
      });
    }

    if (userRole === 'JUNIOR' && (tap === 'scheduled' || tap === 'default') && detail !== 'detail') {
      navigate('/promiseList/promiseDetailJunior', {
        // ✅✅✅ 요부분!! ✅✅✅
        state: {
          tap: 'scheduled',
          myNickname: myNickname,
          appointmentId: profileCardData?.appointmentId,
          seniorId: profileCardData?.seniorId,
        },
      });
    }
...
  };
```
- 해당 로직 사용해서 `약속 디테일 페이지`에서 해당 값을 받아서, 뒤로가기할 때 의 navigate의 state로 전달했습니다

```typescript
// PromiseDetailPage

  // ✅ 여기서 tap 받아와서
  const { tap, myNickname, appointmentId } = location.state;

    <Header
      LeftSvg={ArrowLeftIc}
      onClickLeft={() => navigate(`/promiseList`, {
       // ✅✅ 여기서 전달 ! ✅✅
        state: {
          prevTap: tap
        }
      })}
      title={viewType === 'DEFAULT' ? '자세히 보기' : '거절하기'}
    />
```

- 이렇게 해서, 약속 리스트 페이지에 다시 진입했을 경우, location.state로 받아온 prevTap값을 사용해 렌더링해주었습니다.
- 새로고침했을 때도 location.state가 남아있는 이슈가 있어서, 새로고침시 다시 확정대기 탭으로 이동시켜주기 위해 location.state 초기화 로직 추가해두었습니다.
```typescript
// PromiseTap
  // 사용자가 tap을 클릭했을 때 그에 따른 리스트 렌더링을 관리
  const [tap, setTap] = useState('pending');
  const { userRole, pending, scheduled, past, myNickname } = props;
  
  // ✅✅ 여기서 prevTap 값 받아오기 ! 
  // 뒤로가기로 진입한게 아닌 경우 location.state가 없기 때문에 빈객체 전달 후 아래 useEffect에서 핸들링
  const { prevTap } = location.state || {};

  useEffect(() => {
    if (prevTap && Object.keys(prevTap).length !== 0) {
      setTap(prevTap);
      // ✅ 새로고침시 location.state 초기화 위해
      navigate(location.pathname, { state: '' });
    }
  }, [prevTap]);
```

## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->
이전

https://github.com/user-attachments/assets/2e214529-1a97-492f-b63d-25b8baf22285

변경 후
(페이지 새로고침하면 이전탭보다는 확정대기 탭으로 이동시켜주는게 나을 것 같아서 그렇게 해두었는데, 이전탭에 머무르는게 나으려나요 ? .. )

https://github.com/user-attachments/assets/a3478642-aa4c-4dc4-84d1-ae8a5a5a61e9

