### PR TITLE
[ Fix ] 약속리스트 페이지 레이아웃 조정 / 선배 상세정보(Preview 컴포넌트) 회사 색상 깜빡이는 이슈 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,8 +7,6 @@ import globalStyle from './styles/globalStyle';
 import theme from './styles/theme';
 
 const App = () => {
-  // const navigate = useNavigate();
-
   const setScreenSize = () => {
     // vh 관련
     const vh = window.innerHeight * 0.01;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,7 +43,7 @@ export default App;
 
 const Wrapper = styled.div`
   width: 100vw;
-  min-height: calc(var(--vh, 1vh) * 100 - 44px);
+  min-height: calc(var(--vh, 1vh) * 100 - 54px);
   border: none;
 
   background-color: #fff;

--- a/src/components/commons/Header.tsx
+++ b/src/components/commons/Header.tsx
@@ -50,7 +50,7 @@ const Wrapper = styled.header<{ $hasTitle: boolean; $bgColor: 'grayScaleWhite' |
   z-index: 1;
 
   width: 100vw;
-  height: ${({ $hasTitle }) => ($hasTitle ? '5rem' : '4.4rem')};
+  height: 5rem;
   padding: 1rem 2rem;
 
   background-color: ${({ theme, $bgColor }) => ($bgColor ? theme.colors[$bgColor] : 'transparent')};

--- a/src/components/commons/seniorCard/SeniorCard.tsx
+++ b/src/components/commons/seniorCard/SeniorCard.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { getLevelName } from '../../../utils/getLevelName';
+import { useState } from 'react';
 
 interface seniorListPropType {
   nickname: string;
@@ -19,7 +20,8 @@ interface CompanyProps {
 export const SeniorCard = (props: seniorListPropType) => {
   const { nickname, company, field, position, detailPosition, level, variant = 'default', image } = props;
   const levelName = getLevelName(level);
-  const randomColor = Math.floor(Math.random() * 3);
+  const [randomColor] = useState(Math.floor(Math.random() * 3));
+
   return (
     <SeniorCardWrapper $isSmall={variant === 'secondary'}>
       <SeniorCardLayout>

--- a/src/pages/promiseDetail/PromiseDetailPage.tsx
+++ b/src/pages/promiseDetail/PromiseDetailPage.tsx
@@ -156,7 +156,6 @@ const PromiseDetail = () => {
         onClickLeft={() => navigate('/promiseList')}
         title={viewType === 'DEFAULT' ? '자세히 보기' : '거절하기'}
       />
-      <hr />
       <Wrapper>
         <Layout $viewType={viewType}>
           <TitleContainer>
@@ -327,7 +326,7 @@ const Wrapper = styled.div`
 
   width: 100vw;
   height: 100%;
-  margin-top: 4.4rem;
+  margin-top: 5rem;
   padding: 3rem 1.765rem 0 2.035rem;
   border-top: 1px solid ${({ theme }) => theme.colors.grayScaleLG2};
 

--- a/src/pages/promiseDetail/PromiseDetailPageJunior.tsx
+++ b/src/pages/promiseDetail/PromiseDetailPageJunior.tsx
@@ -58,13 +58,16 @@ const PromiseDetailPageJunior = () => {
     <>
       {isDetailClicked ? (
         <>
-          <Header LeftSvg={ArrowLeftIc} title="내가 보낸 약속" onClickLeft={handleClickBackArrow} />
+          <Header LeftSvg={ArrowLeftIc} onClickLeft={handleClickBackArrow} />
           <Divider />
-          <PreView variant="secondary" seniorId={seniorId} />
+          <DetailWrapper>
+            <PreView variant="secondary" seniorId={seniorId} />
+          </DetailWrapper>
         </>
       ) : (
         <>
-          <Header LeftSvg={ArrowLeftIc} title="자세히 보기" onClickLeft={() => navigate('/promiseList')} />
+          <Header LeftSvg={ArrowLeftIc} title="내가 보낸 약속" onClickLeft={() => navigate('/promiseList')} />
+          <Divider />
           <Wrapper>
             <Layout>
               <TitleContainer>
@@ -128,11 +131,18 @@ const Wrapper = styled.div`
 
   width: 100vw;
   height: 100%;
-  margin-top: 4.4rem;
+  margin-top: 5.2rem;
   padding: 3rem 1.974rem 0 2.026rem;
-  border-top: 1px solid ${({ theme }) => theme.colors.grayScaleLG2};
 
   background-color: ${({ theme }) => theme.colors.grayScaleWhite};
+`;
+
+// 임시 Preview 부분 padding 수정되면 적용필
+const DetailWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  padding-top: 3.2rem;
 `;
 
 const Layout = styled.div`
@@ -198,10 +208,10 @@ const BtnWrapper = styled.div`
   padding: 0 2.035rem 0 1.965rem;
 `;
 
-const Divider = styled.hr`
+const Divider = styled.div`
+  position: fixed;
+  top: 5rem;
+
   width: 100vw;
-  height: 0.1rem;
-  margin-top: 5rem;
-  margin-bottom: 3.2rem;
-  border: 1px solid ${({ theme }) => theme.colors.grayScaleLG2};
+  border: 1.4px solid ${({ theme }) => theme.colors.grayScaleLG2};
 `;

--- a/src/pages/promiseDetail/PromiseDetailPageJunior.tsx
+++ b/src/pages/promiseDetail/PromiseDetailPageJunior.tsx
@@ -12,6 +12,7 @@ import { useState } from 'react';
 import PreView from '@pages/seniorProfile/components/preView';
 import Loading from '@components/commons/Loading';
 import { useGetGoogleMeetLink } from '@pages/promiseList/hooks/queries';
+import ErrorPage from '@pages/errorPage/ErrorPage';
 
 const PromiseDetailPageJunior = () => {
   // 라우터 이동할 때 location으로 약속id, 눌린 탭 상태값(pending, sheduled, ..) 받아와야함
@@ -46,7 +47,7 @@ const PromiseDetailPageJunior = () => {
   }
 
   if (!isSuccess || !timeList1) {
-    return <div>데이터 없음</div>; // 데이터가 없을 때 표시
+    return <ErrorPage />;
   }
 
   const handleClickBackArrow = () => {


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #265 

## ✅ Done Task
  - [x] 약속리스트 페이지 레이아웃 조정
  - [x] 선배 상세정보(Preview 컴포넌트) 회사 색상 깜빡이는 이슈 수정

## ☀️ New-insight
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->
없

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->
- 자잘한 레이아웃 수정했습니다. (헤더 아래 구분선 , 헤더와의 간격 조정 등)
- 진이가 만들어둔 `Preview` 컴포넌트의 `SeniorCard` 컴포넌트에서 회사명에 랜덤색상 부여하는 부분이있는데요
- 해당 컴포넌트는 상위 컴포넌트에서 구글밋 입장 시간 계산하는 함수 때문에 1초마다 리렌더링이 일어나는데, 그것때문에 1초마다 색상이 바뀌는 이슈가 발생했어요
- 때문에 state로 관리하여 변하지 않도록 해두었습니다.
```typescript
// index.ts > Preview > SeniorCard 컴포넌트

  const [randomColor] = useState(Math.floor(Math.random() * 3));

```

-> 하위 컴포넌트에서는 1초마다 리렌더링이 발생하지 않도록 memo같은 거 써서 최적화 해야할 것 같은데, 더 알아보고 하려고 우선은 깜빡이는 부분만 수정해두었어요

## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->
이전

https://github.com/user-attachments/assets/f324d1be-14c1-4c2e-ba17-64908bd024e4

이후

https://github.com/user-attachments/assets/a3a08bbd-8af8-4ba5-9190-8206e3327d69

