### PR TITLE
[ Fix ] 약속신청 사유 하나만 가도록 수정

### DIFF
--- a/src/pages/juniorPromiseRequest/JuniorPromiseRequestPage.tsx
+++ b/src/pages/juniorPromiseRequest/JuniorPromiseRequestPage.tsx
@@ -16,7 +16,6 @@ import { Header } from '@components/commons/Header';
 import Banner from './components/Banner';
 import TitleBox from '@components/commons/TitleBox';
 import { SELECT_JUNIOR_TITLE } from './constants/constants';
-import axios from 'axios';
 
 const JuniorPromiseRequestPage = () => {
   const [activeButton, setActiveButton] = useState('선택할래요');
@@ -86,7 +85,7 @@ const JuniorPromiseRequestPage = () => {
     postAppointment({
       seniorId,
       topic: activeButton === '선택할래요' ? selectedButtons : [],
-      personalTopic: activeButton === '선택할래요' ? '' : inputVal,
+      personalTopic: activeButton === '작성할래요' ? inputVal : '',
       timeList: selectedTime.map((item) => ({
         date: item.clickedDay,
         startTime: item.selectedTime.split('-')[0],


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #268 

## ✅ Done Task
  - [x] 약속 신청 사유 하나만 가도록 수정

## ☀️ New-insight
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->

activeButton이 '작성할래요'인 경우 personalTopic의 조건부 코드에 오류가 있던 것을 발견했습니다.

따라서 activeButton이 '작성할래요'인 경우, personalTopic을 inputVal을 가지도록 하고, '선택할래요'인 경우에는 personalTopic에 빈 문자열을 가지도록 올바르게 수정했습니다.



## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->
첫번째 콘솔 : 토글 버튼이 '작성할래요'인 경우 텍스트 문자열만 전송됨.
두번째 콘솔: 토글 버튼이 '선택할래요'인 경우 선택한 고민 배열만 전송됨.

> 400 오류는 이미 약속 신청한 선배인 경우라 발생했습니다!

<img width="1239" alt="스크린샷 2024-10-12 오후 9 41 30" src="https://github.com/user-attachments/assets/6fddac1b-1a60-4033-ac16-e7927db11dd0">
