### PR TITLE
[ Fix ] 빈 문자열로 약속신청 하는 경우 막기

### DIFF
--- a/src/pages/juniorPromiseRequest/JuniorPromiseRequestPage.tsx
+++ b/src/pages/juniorPromiseRequest/JuniorPromiseRequestPage.tsx
@@ -22,7 +22,6 @@ const JuniorPromiseRequestPage = () => {
   const [activeButton, setActiveButton] = useState('선택할래요');
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isAnyWorrySelected, setIsAnyWorrySelected] = useState(false);
-  const [isTextareaFilled, setIsTextareaFilled] = useState(false);
   const [, setUnfilledFields] = useState<number[]>([]);
   const navigate = useNavigate();
   const location = useLocation();
@@ -71,6 +70,7 @@ const JuniorPromiseRequestPage = () => {
 
   // 작성할래요 인풋 값 가져오기
   const [inputVal, setInputVal] = useState<string>('');
+  const isTextareaFilled = inputVal.trim() !== '';
   const handleAppointmentSendSuccess = () => {
     setIsModalClicked(true);
   };
@@ -95,9 +95,10 @@ const JuniorPromiseRequestPage = () => {
     });
   };
 
+  // 모든 일정 선택했는지 확인. '선택할래요'인 경우 선택했는지 확인, '작성할래요'인 경우 텍스트 입력했는지 확인
   const isAllSelected =
     selectedTime.every((item) => item.selectedTime !== '' && item.clickedDay !== '') &&
-    (isAnyWorrySelected || isTextareaFilled);
+    (activeButton === '선택할래요' ? isAnyWorrySelected : isTextareaFilled);
 
   // 버튼 클릭시 실행 함수
   const handleSubmit = () => {
@@ -137,7 +138,7 @@ const JuniorPromiseRequestPage = () => {
             handleCheckWorrySelected={handleCheckWorrySelected}
           />
         ) : (
-          <WorryTextarea inputVal={inputVal} setInputVal={setInputVal} setIsTextareaFilled={setIsTextareaFilled} />
+          <WorryTextarea inputVal={inputVal} setInputVal={setInputVal} />
         )}
         <CalendarBottomSheet
           selectedTime={selectedTime}

--- a/src/pages/juniorPromiseRequest/JuniorPromiseRequestPage.tsx
+++ b/src/pages/juniorPromiseRequest/JuniorPromiseRequestPage.tsx
@@ -21,7 +21,6 @@ import axios from 'axios';
 const JuniorPromiseRequestPage = () => {
   const [activeButton, setActiveButton] = useState('선택할래요');
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [isAnyWorrySelected, setIsAnyWorrySelected] = useState(false);
   const [, setUnfilledFields] = useState<number[]>([]);
   const navigate = useNavigate();
   const location = useLocation();
@@ -63,11 +62,6 @@ const JuniorPromiseRequestPage = () => {
     setUnfilledFields(unfilled);
   };
 
-  // 걱정 버튼 중 하나라도 선택했는지 확인
-  const handleCheckWorrySelected = (isSelected: boolean) => {
-    setIsAnyWorrySelected(isSelected);
-  };
-
   // 작성할래요 인풋 값 가져오기
   const [inputVal, setInputVal] = useState<string>('');
   const isTextareaFilled = inputVal.trim() !== '';
@@ -98,7 +92,7 @@ const JuniorPromiseRequestPage = () => {
   // 모든 일정 선택했는지 확인. '선택할래요'인 경우 선택했는지 확인, '작성할래요'인 경우 텍스트 입력했는지 확인
   const isAllSelected =
     selectedTime.every((item) => item.selectedTime !== '' && item.clickedDay !== '') &&
-    (activeButton === '선택할래요' ? isAnyWorrySelected : isTextareaFilled);
+    (activeButton === '선택할래요' ? selectedButtons.length > 0 : isTextareaFilled);
 
   // 버튼 클릭시 실행 함수
   const handleSubmit = () => {
@@ -132,11 +126,7 @@ const JuniorPromiseRequestPage = () => {
           onSetActiveButtonHandler={handleToggle}
         />
         {activeButton === '선택할래요' ? (
-          <WorryButtons
-            selectedButtons={selectedButtons}
-            setSelectedButtons={setSelectedButtons}
-            handleCheckWorrySelected={handleCheckWorrySelected}
-          />
+          <WorryButtons selectedButtons={selectedButtons} setSelectedButtons={setSelectedButtons} />
         ) : (
           <WorryTextarea inputVal={inputVal} setInputVal={setInputVal} />
         )}

--- a/src/pages/juniorPromiseRequest/JuniorPromiseRequestPage.tsx
+++ b/src/pages/juniorPromiseRequest/JuniorPromiseRequestPage.tsx
@@ -16,7 +16,6 @@ import { Header } from '@components/commons/Header';
 import Banner from './components/Banner';
 import TitleBox from '@components/commons/TitleBox';
 import { SELECT_JUNIOR_TITLE } from './constants/constants';
-import axios from 'axios';
 
 const JuniorPromiseRequestPage = () => {
   const [activeButton, setActiveButton] = useState('선택할래요');

--- a/src/pages/juniorPromiseRequest/components/WorryButtons.tsx
+++ b/src/pages/juniorPromiseRequest/components/WorryButtons.tsx
@@ -1,6 +1,5 @@
 import WarnDescription from '@components/commons/WarnDescription';
 import styled from '@emotion/styled';
-import React, { useEffect } from 'react';
 import { ButtonCheckIc } from '../../../assets/svgs';
 import { WORRY_SELECTION_BUTTON } from '../constants/constants';
 

--- a/src/pages/juniorPromiseRequest/components/WorryButtons.tsx
+++ b/src/pages/juniorPromiseRequest/components/WorryButtons.tsx
@@ -5,16 +5,11 @@ import { ButtonCheckIc } from '../../../assets/svgs';
 import { WORRY_SELECTION_BUTTON } from '../constants/constants';
 
 interface SelectJuniorWorryButtonProps {
-  handleCheckWorrySelected: (isSelected: boolean) => void;
   selectedButtons: string[];
   setSelectedButtons: React.Dispatch<React.SetStateAction<string[]>>;
 }
 
-const SelectJuniorWorryButton = ({
-  handleCheckWorrySelected,
-  selectedButtons,
-  setSelectedButtons,
-}: SelectJuniorWorryButtonProps) => {
+const SelectJuniorWorryButton = ({ selectedButtons, setSelectedButtons }: SelectJuniorWorryButtonProps) => {
   const handleButtonClick = (title: string) => {
     setSelectedButtons((prevSelectedButtons: string[]) =>
       prevSelectedButtons.includes(title)
@@ -22,10 +17,6 @@ const SelectJuniorWorryButton = ({
         : [...prevSelectedButtons, title]
     );
   };
-
-  useEffect(() => {
-    handleCheckWorrySelected(selectedButtons.length > 0);
-  }, [selectedButtons, handleCheckWorrySelected]);
 
   return (
     <Wrapper>

--- a/src/pages/juniorPromiseRequest/components/WorryTextarea.tsx
+++ b/src/pages/juniorPromiseRequest/components/WorryTextarea.tsx
@@ -1,19 +1,12 @@
-import { useEffect } from 'react';
 import Textarea from '../../../components/commons/Textarea';
 import styled from '@emotion/styled';
 
 interface SelectJuniorWorryTextareaWrapperProps {
-  // eslint-disable-next-line no-unused-vars
-  setIsTextareaFilled: (isFilled: boolean) => void;
   inputVal: string;
   setInputVal: React.Dispatch<React.SetStateAction<string>>;
 }
 
-const WorryTextarea = ({ setIsTextareaFilled, inputVal, setInputVal }: SelectJuniorWorryTextareaWrapperProps) => {
-  useEffect(() => {
-    setIsTextareaFilled(inputVal.length > 0);
-  }, [inputVal, setIsTextareaFilled]);
-
+const WorryTextarea = ({ inputVal, setInputVal }: SelectJuniorWorryTextareaWrapperProps) => {
   const handleInputVal = (val: string) => {
     setInputVal(val);
   };


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #275 

## ✅ Done Task
  - [x] 빈 문자열로 약속신청 하는 경우 막기

## ☀️ New-insight
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->
.trim()을 사용해서 공백이 하나건 두개건 이게 공백인지 아닌지 쉽게 검사할 수 있다!

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->
` const [isTextareaFilled, setIsTextareaFilled] = useState(false); `대신에  `const isTextareaFilled = inputVal.trim() !== '';`으로 inputVal이 공백인지 아닌지 검사하도록 수정했습니다!!


## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->

- 빈 공백만 있는 경우: 약속 신청하기 버튼 불이 안켜짐.
<img width="373" alt="스크린샷 2024-10-12 오후 10 27 22" src="https://github.com/user-attachments/assets/c082a225-269e-456a-b33f-bf8166b62552">


- 한 글자라도 있는 경우: 약속 신청하기 버튼에 불이 켜짐.
<img width="373" alt="스크린샷 2024-10-12 오후 10 27 15" src="https://github.com/user-attachments/assets/99d9132e-4e41-4ad8-91d5-3442556e7e44">
