### PR TITLE
[ Fix ] 닉네임 중복체크 여부 유지

### DIFF
--- a/src/pages/onboarding/components/commonOnboarding/Step개인정보입력.tsx
+++ b/src/pages/onboarding/components/commonOnboarding/Step개인정보입력.tsx
@@ -22,7 +22,7 @@ const Step개인정보입력 = () => {
 
   type nicknameErrorType = 'INVALID' | 'CONFLICT';
   type nicknameStatusType = 'EMPTY' | 'VALID' | nicknameErrorType;
-  const [nicknameStatus, setNicknameStatus] = useState<nicknameStatusType>('EMPTY');
+  const [nicknameStatus, setNicknameStatus] = useState<nicknameStatusType>(data.isNicknameValid ? 'VALID' : 'EMPTY');
 
   const [imageFile, setImageFile] = useState<File | null>(data.imageFile || null);
 
@@ -66,6 +66,7 @@ const Step개인정보입력 = () => {
       imageFile,
       image: res.fileName,
       nickname: nickname,
+      isNicknameValid: true,
     }));
     navigate(pathname.includes('senior') ? '/seniorOnboarding/3' : '/juniorOnboarding/3');
   };

--- a/src/pages/onboarding/type.ts
+++ b/src/pages/onboarding/type.ts
@@ -12,6 +12,7 @@ export interface JoinPropType {
   role: 'SENIOR' | 'JUNIOR';
   isSubscribed: boolean[];
   nickname: string;
+  isNicknameValid: boolean;
   image: string;
   imageFile?: File;
   phoneNumber: string;


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #271 

## ✅ Done Task
  - [x] 닉네임 중복체크 여부 다음단계 넘어갔다가 돌아와도 유지 

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->
기존에는 다음단계로 넘어갔다가 다시 돌아오면 입력했던 닉네임 문자는 유지되지만, 중복체크했던 여부는 유지되지 않아서 매번 다시 중복체크를 했어야 했어요. 
중복체크 여부가 유지될 수 있도록 context data에 `isNicknameValid` 필드를 추가해줬습니다! 

Step개인정보입력 컴포넌트 내에서 nicknameStatus state는 INVALID, CONFLICT, VALID, EMPTY 이런 값을 쓰고 있는데, 왜 context에서는 boolean 값으로 관리해주냐! 하실 수 있는데, 

해당 단계 내에서 어차피 **중복체크status**가 `VALID`된 경우에만 다음단계로 넘아갈 수 있기 때문에, 
다음단계 버튼을 클릭할 경우에 저장되는 context data에서 닉네임은 **항상 유효하다고 보장**할 수 있어요. 그래서 `true` 값으로 바로 넘겨줍니다. 
그리고 다시 단계 돌아왔을 때, 만약 **isNicknameValid**에 `true` 값이 저장되어있다면 **최초로 단계에 진입한게 아니라 이미 중복체크하고 다음단계 넘어왔다가 돌아왔다**는 뜻이니까 **status 초기값**을 `VALID`로, 그게 아니라면 `EMPTY` 상태로 초기화해주도록 구현했어요 ! 

## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->