### PR TITLE
[ Fix ] 온보딩 중 새로고침 시 1단계로 navigate

### DIFF
--- a/src/pages/onboarding/components/Layout.tsx
+++ b/src/pages/onboarding/components/Layout.tsx
@@ -6,7 +6,7 @@ import ProgressBar from '../../../components/commons/ProgressBar';
 import { JUNIOR_ONBOARDING_STEPS, ONBOARDING_HEADER, SENIOR_ONBOARDING_STEPS } from '../constants';
 import convertToGroupStep from '../utils/convertToGroupStep';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { JoinPropType } from '../type';
 
 const Layout = ({ userRole }: { userRole: 'SENIOR' | 'JUNIOR' }) => {
@@ -27,6 +27,13 @@ const Layout = ({ userRole }: { userRole: 'SENIOR' | 'JUNIOR' }) => {
     field: '',
     departmentList: [],
   });
+
+  useEffect(() => {
+    // 리로드 시 1단계로 back
+    if (location.pathname.slice(-1) !== '1') {
+      userRole === 'SENIOR' ? navigate('/seniorOnboarding/1') : navigate('/juniorOnboarding/1');
+    }
+  }, []);
 
   return (
     <Wrapper>


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #272 

## ✅ Done Task
  - [x] 온보딩 중간에 리로드 시 1단계로 튕겨보내기 

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->
### 최초 문제 
최초에 QA시 발견했던 문제는 다른 단계에서 학과 선택 단계로 돌아왔을 때 API 400에러가 뜬다! 였어요 
근데 일반적으로 다음 단계로 넘어간 후 단계를 돌아왔을 때는 같은 문제가 발생하지 않더라고요? 

문제가 발생하는 경우는 **온보딩 중간에 리로드(새로고침)을 했을 때** 였어요! 

![image](https://github.com/user-attachments/assets/25edbefd-9737-4a1f-9858-aab30fd98ddf)

에러나는 모습은 이러한데, 
400에러가 나는 이유는 학과 리스트 조회 API에서 univName에 정상적인 parameter가 들어가지 않았기 때문이에요. 
parameter 변수에 들어가는 데이터가 온보딩 단계 전체를 감싸는 `OutletContext`에서 들고다니는 univName 값인데요, 
이 값을 출력해보니 아무것도 출력되지 않더라고요! (undefined) 

그래서 context로 들고다니는 모든 데이터를 출력해보니까, univName 외의 모든 데이터가 초기화된 것을 볼 수 있었어요
![image](https://github.com/user-attachments/assets/a279cf92-c1ac-44cf-8260-e0ff1f06734b)

이렇게 데이터가 초기화된 이유는 리로드(새로고침)이 발생했기 때문이에요. 
원래의 일반적인 경우엔, 이렇게 새로고침을 통해 들고다니던 상태값이 초기화될 경우, 첫 단계로 튕겨져 나가서 다시 처음부터 작성하도록 유도해야 하는데, 
저희 서비스 같은 경우엔 각 온보딩 단계가 funnel 구조가 아닌 **각기다른 URL로 분리** 되어있어서 데이터가 다 날아감에도 불구하고 진행중인 단계의 화면은 유지되어요. 그럼 사용자는 앞단의 데이터가 잘 보관되고 있다고 착각할 수 있겠죠? 

그래서 이 문제에 대한 해결책으로, **온보딩 과정 중에 새로고침이 발생했을 경우엔 무조건 1단계로 사용자를 보내버리기!** 를 추가했습니다.
이를 위해 모든 온보딩 페이지를 감싸고 있는 부모 컴포넌트인 Layout 내부에서 
`Layout` 컴포넌트가 **mount되었을 때** (useEffect + 빈 의존성) 온보딩 중간 단계일 경우 다시 1단계로 navigate 시키는 코드를 추가했습니다. 

개선된 녹화영상은 스크린샷 참고해주세용 ~ 

```ts
  useEffect(() => {
    // 리로드 시 1단계로 back
    if (location.pathname.slice(-1) !== '1') {
      userRole === 'SENIOR' ? navigate('/seniorOnboarding/1') : navigate('/juniorOnboarding/1');
    }
  }, []);
```

## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->

https://github.com/user-attachments/assets/7ab2d1f8-a81a-46a4-b775-e8dcf3017b8e


