### PR TITLE
[ Design ] 후배 약속신청 확인 모달 위치 수정

### DIFF
--- a/src/pages/juniorPromiseRequest/components/RequestComplete.tsx
+++ b/src/pages/juniorPromiseRequest/components/RequestComplete.tsx
@@ -57,7 +57,6 @@ const Wrapper = styled.div`
   align-items: center;
   position: fixed;
   top: 0;
-  left: 0;
   z-index: 10;
 
   width: 100%;


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #285 

## ✅ Done Task
  - [x] 후배 약속신청 확인 모달 위치 수정

## ☀️ New-insight
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->
left:0 으로 왼쪽에 붙어있던 모달 페이지를 가운데로 옮겨줬습니다

## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->
- 이전 뷰
<img width="1582" alt="스크린샷 2024-10-08 오전 12 55 35" src="https://github.com/user-attachments/assets/67206d14-b824-4d14-9ca3-773c3db4bfeb">

- 고친 뷰
<img width="1582" alt="스크린샷 2024-10-15 오전 12 10 50" src="https://github.com/user-attachments/assets/dcbbc2d5-aa3f-4a83-b9f4-de0b161014e5">
