### PR TITLE
[ Fix ] 휴대폰에서 캘린더 바텀시트 밀리는 현상 해결

### DIFF
--- a/src/pages/juniorPromiseRequest/components/CalendarBottomBar.tsx
+++ b/src/pages/juniorPromiseRequest/components/CalendarBottomBar.tsx
@@ -80,8 +80,8 @@ const ButtonLayout = styled.footer`
   gap: 1.1rem;
   justify-content: center;
   position: fixed;
-  bottom: 5rem;
-  left: 0;
+  bottom: 0;
+  left: 50%;
 
   width: 100%;
   height: 9.4rem;
@@ -89,6 +89,8 @@ const ButtonLayout = styled.footer`
 
   background: ${({ theme }) => theme.colors.grayScaleWhite};
   box-shadow: 0 -8px 30px rgb(0 0 0 / 10%);
+
+  transform: translate(-50%, -50%);
 `;
 
 const ReloadBtn = styled.button`

--- a/src/pages/juniorPromiseRequest/components/CalendarBottomSheet.tsx
+++ b/src/pages/juniorPromiseRequest/components/CalendarBottomSheet.tsx
@@ -7,6 +7,7 @@ import { useSeniorTimeQuery } from '../hooks/queries';
 import { getDayOfWeek } from '../utils/getDay';
 import Loading from '@components/commons/Loading';
 import { BottomSheetRectangleIc } from '@assets/svgs';
+import { Wrapper } from '@pages/seniorProfile/components/TimeSelect/TimeWeekdays';
 
 interface BottomSheetPropType {
   selectedTime: { id: number; selectedTime: string; clickedDay: string }[];
@@ -98,13 +99,14 @@ const BottomSheetRectangleIcon = styled(BottomSheetRectangleIc)`
 
 const Background = styled.div<{ $isCalendarOpen: boolean }>`
   display: ${({ $isCalendarOpen }) => ($isCalendarOpen ? 'flex' : 'none')};
-  position: fixed;
-  top: 0;
+  position: absolute;
+  left: 50%;
   z-index: 2;
+
+  transform: translate(-50%, -50%);
 
   width: 100%;
   height: 100dvh;
-  margin-left: -2rem;
 
   background: ${({ theme }) => theme.colors.transparentBlack_65};
 `;
@@ -115,11 +117,11 @@ const BottomSheetWrapper = styled.div<{ $isCalendarOpen: boolean }>`
   position: fixed;
   top: 5rem;
   bottom: 0;
+  left: 50%;
   z-index: 4;
 
   width: 100%;
   height: 100vh;
-  margin-left: -2rem;
   padding: 3.8rem 0 0;
   border-radius: 16px 16px 0 0;
 
@@ -129,7 +131,7 @@ const BottomSheetWrapper = styled.div<{ $isCalendarOpen: boolean }>`
   transition:
     transform 250ms ease-out,
     opacity 250ms ease-out;
-  transform: translateY(${({ $isCalendarOpen }) => ($isCalendarOpen ? '0' : '100%')});
+  transform: translate(-50%, ${({ $isCalendarOpen }) => ($isCalendarOpen ? '0' : '100%')});
 `;
 
 const GrayLine = styled.div`


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #306 

## ✅ Done Task
  - [x] 휴대폰에서 봤을때 바텀시트 살짝 밀린 현상 해결

## ☀️ New-insight
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->
```
left: 50%
transform: translate(-50%, -50%);
```
해당 코드로 가운데 정렬을 해줬습니다

## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->
휴대폰에서만 밀림 현상이 발생해서 배포 후 폰으로 확인할 수 있을 것 같습니다!!!

<img width="427" alt="스크린샷 2024-10-28 오후 11 50 38" src="https://github.com/user-attachments/assets/d3a6885f-b906-4121-bab0-d13d3672deab">
