### PR TITLE
Fix/#311/2nd issue

### DIFF
--- a/src/pages/onboarding/components/Layout.tsx
+++ b/src/pages/onboarding/components/Layout.tsx
@@ -81,7 +81,6 @@ const Content = styled.section`
 const ButtonBg = styled.footer`
   position: fixed;
   bottom: 0;
-  left: 0;
 
   width: 100vw;
   height: 6.4rem;

--- a/src/pages/onboarding/components/TextBox.tsx
+++ b/src/pages/onboarding/components/TextBox.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { InputHTMLAttributes, ReactNode } from 'react';
+import { InputHTMLAttributes, ReactNode, forwardRef } from 'react';
 
 interface InnerButtonProps {
   text: string;
@@ -23,14 +23,10 @@ interface InputBoxPropType
   children?: ReactNode;
 }
 
-export const InputBox = ({
-  label,
-  children,
-  isError = false,
-  type = 'text',
-  text,
-  ...inputElements
-}: InputBoxPropType) => {
+export const InputBox = forwardRef<HTMLInputElement, InputBoxPropType>(function InputBox(
+  { label, children, isError = false, type = 'text', text, ...inputElements },
+  ref
+) {
   return (
     <InputWrapper>
       {type === 'text' ? (
@@ -38,13 +34,13 @@ export const InputBox = ({
       ) : (
         <FileLabel $isError={isError}>
           <FileText $isDefault={text === inputElements.placeholder}>{text}</FileText>
-          <FileInput type="file" accept="image/*, .pdf" {...inputElements} />
+          <FileInput type="file" accept="image/*, .pdf" ref={ref} {...inputElements} />
         </FileLabel>
       )}
       {children}
     </InputWrapper>
   );
-};
+});
 
 export const Caption = ({ children, isValid = false }: { children: string; isValid?: boolean }) => {
   return <CaptionText $isValid={isValid}>{children}</CaptionText>;

--- a/src/pages/onboarding/components/commonOnboarding/Step개인정보입력.tsx
+++ b/src/pages/onboarding/components/commonOnboarding/Step개인정보입력.tsx
@@ -39,10 +39,7 @@ const Step개인정보입력 = () => {
 
   const handleChangeInput = (e: ChangeEvent<HTMLInputElement>) => {
     setNickname(e.target.value);
-
-    if (e.target.value.length == 0) {
-      setNicknameStatus('EMPTY');
-    }
+    setNicknameStatus('EMPTY');
   };
 
   const handleCheckNickname = () => {

--- a/src/pages/onboarding/components/juniorOnboarding/Step이메일입력.tsx
+++ b/src/pages/onboarding/components/juniorOnboarding/Step이메일입력.tsx
@@ -18,9 +18,12 @@ const Step이메일입력 = () => {
   const navigate = useNavigate();
   const { univName } = useLocation().state;
 
+  const handleClickLink = () => {
+    navigate('/juniorOnboarding/6');
+  };
+
   const verifyMutation = useUnivVerify();
   const verifycodeMutation = useUnivVerifycode();
-  console.log({ verifycodeMutation });
   const [isEmailError, setIsEmailError] = useState(false);
   const [isValidCodeError, setIsValidCodeError] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -95,7 +98,20 @@ const Step이메일입력 = () => {
   };
 
   const handleClickButton = () => {
-    navigate('/juniorOnboarding/6');
+    verifycodeMutation.mutate(
+      { email, univName, code },
+      {
+        onSuccess: () => {
+          setIsModalOpen(true);
+          setTimeout(() => {
+            handleClickLink();
+          }, 2000);
+        },
+        onError: () => {
+          setIsValidCodeError(true);
+        },
+      },
+    );
   };
 
   const handleShowAlreadyModal = (type: boolean) => {

--- a/src/pages/onboarding/components/juniorOnboarding/Step이메일입력.tsx
+++ b/src/pages/onboarding/components/juniorOnboarding/Step이메일입력.tsx
@@ -18,10 +18,6 @@ const Step이메일입력 = () => {
   const navigate = useNavigate();
   const { univName } = useLocation().state;
 
-  const handleClickLink = () => {
-    navigate('/juniorOnboarding/6');
-  };
-
   const verifyMutation = useUnivVerify();
   const verifycodeMutation = useUnivVerifycode();
   console.log({ verifycodeMutation });
@@ -99,21 +95,7 @@ const Step이메일입력 = () => {
   };
 
   const handleClickButton = () => {
-    handleClickLink();
-    // verifycodeMutation.mutate(
-    //   { email, univName, code },
-    //   {
-    //     onSuccess: () => {
-    //       setIsModalOpen(true);
-    //       setTimeout(() => {
-    //         handleClickLink();
-    //       }, 2000);
-    //     },
-    //     onError: () => {
-    //       setIsValidCodeError(true);
-    //     },
-    //   },
-    // );
+    navigate('/juniorOnboarding/6');
   };
 
   const handleShowAlreadyModal = (type: boolean) => {

--- a/src/pages/onboarding/components/seniorOnboarding/Step졸업인증.tsx
+++ b/src/pages/onboarding/components/seniorOnboarding/Step졸업인증.tsx
@@ -94,5 +94,4 @@ const Img = styled.img`
 const ModalWrapper = styled.div`
   width: 100%;
   height: 100%;
-  margin-left: -2rem;
 `;

--- a/src/pages/onboarding/components/seniorOnboarding/Step졸업인증.tsx
+++ b/src/pages/onboarding/components/seniorOnboarding/Step졸업인증.tsx
@@ -1,7 +1,7 @@
 import { AutoCloseModal } from '@components/commons/modal/AutoCloseModal';
 import WarnDescription from '@components/commons/WarnDescription';
 import styled from '@emotion/styled';
-import { ChangeEvent, useState } from 'react';
+import { ChangeEvent, useRef, useState } from 'react';
 import { Caption, InnerButton, InputBox, TextBox } from '../TextBox';
 import { FullBtn } from '@components/commons/FullButton';
 import { useNavigate } from 'react-router-dom';
@@ -41,19 +41,26 @@ const Step졸업인증 = () => {
     setSuccess(type);
   };
 
+  const fileRef = useRef<HTMLInputElement>(null);
+  const handleClickFile = () => {
+    if (!fileRef.current) return;
+    fileRef.current.click();
+  };
+
   return (
     <>
       <Wrapper>
         <div style={{ padding: '0 2rem' }}>
           <TextBox label="졸업증명서">
             <InputBox
+              ref={fileRef}
               label="졸업증명서"
               type="file"
               onChange={handleChangeFile}
               text={file ? file.name : DEFAULT_TEXT}
               placeholder={DEFAULT_TEXT}
               isError={isError}>
-              <InnerButton text="첨부파일" />
+              <InnerButton text="첨부파일" onClick={handleClickFile} />
             </InputBox>
             {isError ? (
               <WarnDescription isShown={isError} warnText="인증에 실패했어요. 학교명이 잘 보이는 지 확인해 주세요." />

--- a/src/pages/onboarding/components/seniorOnboarding/Step직무선택.tsx
+++ b/src/pages/onboarding/components/seniorOnboarding/Step직무선택.tsx
@@ -44,6 +44,7 @@ const Step직무선택 = () => {
               label="세부 직무"
               placeholder="구체적인 직무를 작성해 주세요"
               onChange={(e) => setDetailJob(e.target.value)}
+              maxLength={25}
             />
             <Caption>최대 25자까지 작성할 수 있어요</Caption>
           </TextBox>


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #311 

## ✅ Done Task
> 2차 QA에서 발견된 친구들 중 자잘한 작업을 해결 가능한 아이들 한번에 작업해주었습니다

- [x] 이메일 입력 - 타이머로 인한 초단위 콘솔 출력 제거
- [x] 닉네임 변경 시 중복확인 체크 여부 초기화
- [x] 졸업증명서 첨부 input 첨부파일 버튼 클릭 안되는 이슈 개선
- [x] 졸업 증명서 인증 성공 모달 위치 조정
- [x] 데탑뷰 좌측 하단 흰 박스 제거
- [x] 세부 직무 글자수 제한 추가


## 💎 PR Point

> 여러 작업을 한 PR에서 진행하다보니 코드리뷰하기 복잡할 것 같아서 태스크 단위로 commit 끊어놨어요! 
아래에 작업별로 commit 링크 연결해두었으니, 해당 커밋 열어놓고 코드리뷰 하는게 훨씬 보기 편하실거예요

<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->
1️⃣ **[닉네임 변경 시 중복확인 체크 여부 초기화](https://github.com/TEAM-SEONYAK/SEONYAK_CLIENT/commit/71c60d44e6f8db9c5a02de9f54ad2cd6b7742d66)**
중복체크 한 이후에 닉네임 Input 에 change 이벤트가 발생하면 무조건 nicknameStatus를 "EMPTY"로 바꿔주도록 수정했어요. 
입력해둔 닉네임을 수정했을 경우 반드시 다시 중복체크를 받아야 하도록! 

2️⃣ **[졸업증명서 첨부 input 첨부파일 버튼 클릭 안되는 이슈 개선](https://github.com/TEAM-SEONYAK/SEONYAK_CLIENT/commit/6c318dbdf50ec33e177319746818d7b0f56089af)**
공통 컴포넌트 사용하는 곳이라 구조가 
```html
<label>
  <input/>
  <button/>
</label>
```
이렇게 되어있어서 button 영역에 label 클릭시 발생하는 이벤트 (file input 열림)이 막히고 있었어요 

button onClick에 별도로 이벤트를 연결해줘야했기 때문에 
[`forwardRef`](https://ko.react.dev/reference/react/forwardRef#my-component-is-wrapped-in-forwardref-but-the-ref-to-it-is-always-null) 사용해서 **공통Input컴포넌트 내부로 ref를 전달해주고**, 밖에서 InnerButton의 onClick으로 `ref.current.click()` 넣어줘서 이벤트 연결시켜줬습니다! 

```tsx
const fileRef = useRef<HTMLInputElement>(null);
const handleClickFile = () => {
  if (!fileRef.current) return;
  fileRef.current.click();
};
```

[forwardRef type 관련 참고자료](https://react-typescript-cheatsheet.netlify.app/docs/basic/getting-started/forward_and_create_ref/)


3️⃣ **[졸업 증명서 인증 성공 모달 위치 조정](https://github.com/TEAM-SEONYAK/SEONYAK_CLIENT/commit/d551e1353beb7573c732478d2635364f7475bfdd)**
이상한 margin-left 들어가있던거 빼줘서 해결했어용 

4️⃣ **[데탑뷰 좌측 하단 흰 박스 제거](https://github.com/TEAM-SEONYAK/SEONYAK_CLIENT/commit/40d1642d6f0825bc98d2d91080ba420d3ddb383c)**
<img src="https://github.com/user-attachments/assets/54ecb2d8-d2fb-4af2-b6d3-0f1d689fbc91" width="300"/>

이렇게 이상한 흰 박스가 있었는데, 잘못 들어간 친구인줄알았는데 알고보니까 

<img width="300" src="https://github.com/user-attachments/assets/fe8f58c7-9ff1-4eee-b50a-611c3595449a"/>

이렇게 스크롤 영역 생길 때 FullBtn 아래로 스크롤 콘텐츠가 삐져나오지 않게 하기 위해 배경 깔아주는 용도더라구요 
근데 `left:0` 때문에 왼쪽에 치우쳐있던거라 left:0 빼서 제자리에 쏙 넣어줬어요 

5️⃣ **[세부 직무 글자수 제한 추가](https://github.com/TEAM-SEONYAK/SEONYAK_CLIENT/commit/b14d12dfb5d196211dc034d31f7ad3b2a024c349)**
maxLength 추가해주었어요

---

## 📸 Screenshot
1️⃣ **닉네임 변경 시 중복확인 체크 여부 초기화**

https://github.com/user-attachments/assets/84ba6fc0-f982-43a5-a5a3-2ba2ca000c7c


2️⃣ **졸업증명서 첨부 input 첨부파일 버튼 클릭 안되는 이슈 개선**

https://github.com/user-attachments/assets/b11e4ec7-8638-49ff-af75-476e96c77c1d



3️⃣ **졸업 증명서 인증 성공 모달 위치 조정** 

<img height="400" src="https://github.com/user-attachments/assets/a43bc8b6-7168-4fa1-bfe8-0bdfb3ed411e"/>
👉🏽👉🏽👉🏽
<img height="400" src="https://github.com/user-attachments/assets/440804c1-1454-4f16-9227-48e54d90516f"/>



4️⃣ **데탑뷰 좌측 하단 흰 박스 제거**

<img width="200" src="https://github.com/user-attachments/assets/54ecb2d8-d2fb-4af2-b6d3-0f1d689fbc91"/> 
👉🏽👉🏽👉🏽
<img width="200" src="https://github.com/user-attachments/assets/5ef78f89-7b73-4eab-b1c2-61bd49a9bd96"/>



5️⃣ **세부 직무 글자수 제한 추가**

https://github.com/user-attachments/assets/b81caf6e-f621-4ca1-9c93-040026b5207b


