### PR TITLE
[ Fix ] 후배 온보딩 완료 뷰 개선 

### DIFF
--- a/src/pages/onboarding/components/Layout.tsx
+++ b/src/pages/onboarding/components/Layout.tsx
@@ -35,6 +35,7 @@ const Layout = ({ userRole }: { userRole: 'SENIOR' | 'JUNIOR' }) => {
     }
   }, []);
 
+  if (location.pathname === '/juniorOnboarding/complete') return <Outlet />;
   return (
     <Wrapper>
       <Header

--- a/src/pages/onboarding/components/Layout.tsx
+++ b/src/pages/onboarding/components/Layout.tsx
@@ -35,7 +35,7 @@ const Layout = ({ userRole }: { userRole: 'SENIOR' | 'JUNIOR' }) => {
     }
   }, []);
 
-  if (location.pathname === '/juniorOnboarding/complete') return <Outlet />;
+  if (location.pathname === '/juniorOnboarding/complete') return <Outlet context={{ data }} />;
   return (
     <Wrapper>
       <Header

--- a/src/pages/onboarding/components/juniorOnboarding/StepComplete.tsx
+++ b/src/pages/onboarding/components/juniorOnboarding/StepComplete.tsx
@@ -1,17 +1,13 @@
 import { ProfileCompleteImg } from '@assets/images';
 import styled from '@emotion/styled';
-import { JoinContextType } from '@pages/onboarding/type';
-import { useOutletContext } from 'react-router-dom';
 
 const StepComplete = () => {
-  const { data } = useOutletContext<JoinContextType>();
-
   return (
     <Wrapper>
       <Title>
-        {data.nickname} 후배님
+        고생하셨어요!
         <br />
-        반가워요!
+        회원가입이 완료되었어요
       </Title>
       <Description>바로 선약을 시작하고, 선배와 약속을 잡아보세요</Description>
       <Img src={ProfileCompleteImg} alt="" />

--- a/src/pages/onboarding/components/juniorOnboarding/StepComplete.tsx
+++ b/src/pages/onboarding/components/juniorOnboarding/StepComplete.tsx
@@ -1,7 +1,16 @@
 import { ProfileCompleteImg } from '@assets/images';
 import styled from '@emotion/styled';
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 const StepComplete = () => {
+  const navigate = useNavigate();
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      navigate('/juniorPromise');
+    }, 3000);
+    return () => clearTimeout(timer);
+  }, []);
   return (
     <Wrapper>
       <Title>

--- a/src/pages/onboarding/components/juniorOnboarding/StepComplete.tsx
+++ b/src/pages/onboarding/components/juniorOnboarding/StepComplete.tsx
@@ -1,9 +1,11 @@
 import { ProfileCompleteImg } from '@assets/images';
 import styled from '@emotion/styled';
+import { JoinContextType } from '@pages/onboarding/type';
 import { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useOutletContext } from 'react-router-dom';
 
 const StepComplete = () => {
+  const { data } = useOutletContext<JoinContextType>();
   const navigate = useNavigate();
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -14,9 +16,9 @@ const StepComplete = () => {
   return (
     <Wrapper>
       <Title>
-        고생하셨어요!
+        {data.nickname} 후배님
         <br />
-        회원가입이 완료되었어요
+        반가워요!
       </Title>
       <Description>바로 선약을 시작하고, 선배와 약속을 잡아보세요</Description>
       <Img src={ProfileCompleteImg} alt="" />


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #313 

## ✅ Done Task
- [x] 완료 뷰 GUI 수정 
- [x] 3초 뒤 /juniorPromise로 자동 이동 추가 

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->

<img width="300" src="https://github.com/user-attachments/assets/accc9a59-0b86-4ede-af12-280328da5f8a"/>

예림언니가 제보해준 후배 온보딩 완료 뷰 모습인데요 
원인을 찾아보니 후배 온보딩 완료 뷰가 원래 별도의 페이지로 있었다가, 
url 정리하는 과정에서 `<Layout/>` 컴포넌트의 children들 (다른 step들과 같이)로 넣어주면서 
다른 온보딩 뷰들처럼 헤더와 제목이 자동으로 적용돼서 레이아웃이 밀린 문제였어요! 

그래서 Layout 컴포넌트에서 `location.pathname` 검사해서 
후배 온보딩 뷰일 경우, 감싸고있는 Wrapper들 다 제외하고 Outlet 만 return 할 수 있도록 조건부 렌더링 추가해서 해결해주었습니다! 

추가로 
- 피그마 확인해보니 해당 뷰 라이팅이 달라져있길래 이 부분도 반영했구, 
- 자동 navigate 처리도 누락되어있길래 추가해주었습니다! 

학교 이메일 인증이 막혀있는 이슈로 후배 온보딩 뒷부분 QA가 부족했네요... 🥲 담부터 더 꼼꼼히 보겠습니당 

## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->


https://github.com/user-attachments/assets/0291d734-4f62-49d3-b8e9-0ebb74a6e16a

