### PR TITLE
[ Feat ] 에러페이지 변경사항 적용

### DIFF
--- a/src/pages/errorPage/ErrorPage.tsx
+++ b/src/pages/errorPage/ErrorPage.tsx
@@ -1,17 +1,23 @@
 import styled from '@emotion/styled';
-import { getRole } from '@utils/storage';
-import { useNavigate } from 'react-router-dom';
+// import { getRole } from '@utils/storage';
+// import { useNavigate } from 'react-router-dom';
 import img_waring from '@assets/images/img_warning.png';
+import { FullBtn } from '@components/commons/FullButton';
 
 const ErrorPage = () => {
-  const navigate = useNavigate();
-  const role = getRole();
-  const navPath = role === 'SENIOR' ? '/promiseList' : '/juniorPromise';
+  // const navigate = useNavigate();
+  // const role = getRole();
+  // const navPath = role === 'SENIOR' ? '/promiseList' : '/juniorPromise';
   return (
     <Wrapper>
       <WarningImg src={img_waring} />
       <Meta>오류가 발생했어요</Meta>
-      <Description onClick={() => navigate(navPath)}>홈으로</Description>
+      <Description>궁금한 사항이 해결되지 않으셨나요?</Description>
+      <LinkLayout>
+        <Link>고객센터</Link>
+        <Link>자주 묻는 질문</Link>
+      </LinkLayout>
+      <FullBtn text='홈으로'/>
     </Wrapper>
   );
 };
@@ -34,19 +40,38 @@ const WarningImg = styled.img`
 `;
 
 const Meta = styled.p`
-  margin-top: 3rem;
+  margin-top: 2.4rem;
 
   color: ${({ theme }) => theme.colors.grayScaleBG};
 
-  ${({ theme }) => theme.fonts.Head2_SB_18};
+  ${({ theme }) => theme.fonts.Head1_B_20};
 `;
 
 const Description = styled.p`
-  margin-top: 0.7rem;
+  margin-top: 0.8rem;
+
+  color: ${({ theme }) => theme.colors.grayScaleMG1};
+  text-align: center;
+  white-space: nowrap;
+
+  ${({ theme }) => theme.fonts.Title1_SB_16};
+`;
+
+const LinkLayout = styled.div`
+  display: flex;
+  gap: 2.4rem;
+  justify-content: center;
+  align-items: center;
+`;
+
+const Link = styled.p`
+  margin-top: 1.6rem;
 
   color: ${({ theme }) => theme.colors.grayScaleMG1};
   text-align: center;
   text-decoration: underline;
-  text-underline-offset: 0.3rem;
-  ${({ theme }) => theme.fonts.Title2_R_16};
+
+  text-underline-offset: 0.2rem;
+
+  ${({ theme }) => theme.fonts.Title1_SB_16};
 `;

--- a/src/pages/errorPage/ErrorPage.tsx
+++ b/src/pages/errorPage/ErrorPage.tsx
@@ -6,12 +6,11 @@ import { FullBtn } from '@components/commons/FullButton';
 const ErrorPage = () => {
   const navigate = useNavigate();
 
-  const homeButton = () => {
-    // 로컬스토리지 초기화
+  const handleHomeButton = () => {
     localStorage.clear();
-    // 루트 경로로 navigate
     navigate('/');
   };
+
   return (
     <Wrapper>
       <WarningImg src={img_waring} />
@@ -21,7 +20,7 @@ const ErrorPage = () => {
         <Link>고객센터</Link>
         <Link>자주 묻는 질문</Link>
       </LinkLayout>
-      <FullBtn text="홈으로" onClick={() => homeButton()} />
+      <FullBtn text="홈으로" onClick={() => handleHomeButton()} />
     </Wrapper>
   );
 };

--- a/src/pages/errorPage/ErrorPage.tsx
+++ b/src/pages/errorPage/ErrorPage.tsx
@@ -3,13 +3,20 @@ import { useNavigate } from 'react-router-dom';
 import img_waring from '@assets/images/img_warning.png';
 import { FullBtn } from '@components/commons/FullButton';
 
+const URLS = {
+  customerCenter: 'https://tally.so/r/3XB0Wz',
+  askedQuestion: 'https://cumbersome-cactus-843.notion.site/f4c466a64a914980a0b2794891790505',
+};
+
 const ErrorPage = () => {
   const navigate = useNavigate();
 
-  const handleHomeButton = () => {
+  const handleHomeBtn = () => {
     localStorage.clear();
     navigate('/');
   };
+
+  const handleOpenUrl = (url: string) => window.open(url);
 
   return (
     <Wrapper>
@@ -17,10 +24,10 @@ const ErrorPage = () => {
       <Meta>오류가 발생했어요</Meta>
       <Description>궁금한 사항이 해결되지 않으셨나요?</Description>
       <LinkLayout>
-        <Link>고객센터</Link>
-        <Link>자주 묻는 질문</Link>
+        <Link onClick={() => handleOpenUrl(URLS.customerCenter)}>고객센터</Link>
+        <Link onClick={() => handleOpenUrl(URLS.askedQuestion)}>자주 묻는 질문</Link>
       </LinkLayout>
-      <FullBtn text="홈으로" onClick={() => handleHomeButton()} />
+      <FullBtn text="홈으로" onClick={() => handleHomeBtn()} />
     </Wrapper>
   );
 };

--- a/src/pages/errorPage/ErrorPage.tsx
+++ b/src/pages/errorPage/ErrorPage.tsx
@@ -1,13 +1,17 @@
 import styled from '@emotion/styled';
-// import { getRole } from '@utils/storage';
-// import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import img_waring from '@assets/images/img_warning.png';
 import { FullBtn } from '@components/commons/FullButton';
 
 const ErrorPage = () => {
-  // const navigate = useNavigate();
-  // const role = getRole();
-  // const navPath = role === 'SENIOR' ? '/promiseList' : '/juniorPromise';
+  const navigate = useNavigate();
+
+  const homeButton = () => {
+    // 로컬스토리지 초기화
+    localStorage.clear();
+    // 루트 경로로 navigate
+    navigate('/');
+  };
   return (
     <Wrapper>
       <WarningImg src={img_waring} />
@@ -17,7 +21,7 @@ const ErrorPage = () => {
         <Link>고객센터</Link>
         <Link>자주 묻는 질문</Link>
       </LinkLayout>
-      <FullBtn text='홈으로'/>
+      <FullBtn text="홈으로" onClick={() => homeButton()} />
     </Wrapper>
   );
 };

--- a/src/pages/errorPage/ErrorPage.tsx
+++ b/src/pages/errorPage/ErrorPage.tsx
@@ -84,4 +84,5 @@ const Link = styled.p`
   text-underline-offset: 0.2rem;
 
   ${({ theme }) => theme.fonts.Title1_SB_16};
+  cursor: pointer;
 `;


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #321 

## ✅ Done Task
  - [x] 에러페이지 변경사항 반영
  - [x] 홈으로 버튼 누르면 로컬스토리지 초기화 후 루트 path로 navigate 시키기

## ☀️ New-insight
## 💎 PR Point
1️⃣ 변경된 피그마 뷰에 맞게 변경완료했습니다.

2️⃣ 홈이동 버튼 클릭시 로컬스토리지를 비우고 루트path로 이동하도록 구현했습니다.

3️⃣ 새로운 창으로 고객센터, 자주묻는질문 링크로 이동하도록 구현했습니다.

## 📸 Screenshot
1️⃣
- SE 사이즈
<img width="388" alt="SE 사이즈" src="https://github.com/user-attachments/assets/24086257-e244-48a8-965d-f4c1904ed195">

- 데탑
<img width="443" alt="데탑" src="https://github.com/user-attachments/assets/a12c6a3b-b6c3-432b-9882-c89146fb6b25">
<br/>
2️⃣ 홈이동구현(오른쪽 로컬스토리지 참고)


https://github.com/user-attachments/assets/60c93a12-78df-4af0-bb31-e672fe000ed4



3️⃣
- 고객센터이동

https://github.com/user-attachments/assets/dfce1b21-26a5-4ac8-91ff-41a64f20c4c2


- 자주묻는질문 이동

https://github.com/user-attachments/assets/431e6e61-fde8-4af5-a5f7-cfde92c65aa7



