### PR TITLE
[ Feat ] OCR 검증 과정 로딩 상태 가시화 

### DIFF
--- a/src/components/commons/Loading.tsx
+++ b/src/components/commons/Loading.tsx
@@ -7,7 +7,7 @@ import SpinnerJson from '../../assets/lottie/spinner_light.json';
 type LottiePlayer = typeof lottie.default;
 const lottiePlayer = lottie as any as LottiePlayer;
 
-const Loading = () => {
+const Loading = ({ isTransparent = false }: { isTransparent?: boolean }) => {
   //lottie
   const likecontainer = useRef<HTMLDivElement>(null!);
   useEffect(() => {
@@ -27,7 +27,7 @@ const Loading = () => {
   }, []);
 
   return (
-    <Wrapper>
+    <Wrapper $isTransparent={isTransparent}>
       <NoMore ref={likecontainer}></NoMore>
     </Wrapper>
   );
@@ -39,21 +39,21 @@ const NoMore = styled.div`
   left: 50%;
   transform: translate(-50%, -50%);
 
-  z-index: 999;
-
   width: 12rem;
   height: 12rem;
 `;
 
-const Wrapper = styled.div`
+const Wrapper = styled.div<{ $isTransparent: boolean }>`
   display: flex;
   position: fixed;
   bottom: 0;
+  z-index: 999;
 
   width: 100%;
   height: 100%;
 
-  background-color: ${({ theme }) => theme.colors.grayScaleWhite};
+  background-color: ${({ $isTransparent, theme }) =>
+    $isTransparent ? theme.colors.transparentBlack_65 : theme.colors.grayScaleWhite};
 `;
 
 export default Loading;

--- a/src/pages/onboarding/components/seniorOnboarding/Step명함인증.tsx
+++ b/src/pages/onboarding/components/seniorOnboarding/Step명함인증.tsx
@@ -10,6 +10,7 @@ import { InputBox, TextBox } from '../TextBox';
 import { useBusinessCardQuery } from '@pages/onboarding/hooks/useBusinessCardQuery';
 import { BizInfoType, JoinContextType } from '@pages/onboarding/type';
 import { useBusinessCardPresignedUrl } from '@pages/onboarding/hooks/usePresignedUrl';
+import Loading from '@components/commons/Loading';
 
 const Step명함인증 = () => {
   const { setData } = useOutletContext<JoinContextType>();
@@ -31,6 +32,7 @@ const Step명함인증 = () => {
     if (!e.target.files) return;
     const file = e.target.files[0];
     setImageFile(file);
+    setOpen(false);
 
     mutation.mutate(file, {
       onSuccess: (res) => {
@@ -50,15 +52,16 @@ const Step명함인증 = () => {
     navigate('/seniorOnboarding/8');
   };
 
-  const VerificationDone = () =>
-    info && (
+  const VerificationDone = () => (
+    <>
+      {mutation.isPending && <Loading isTransparent />}
       <DoneWrapper>
         <div style={{ padding: '0 2rem', display: 'flex', flexDirection: 'column', gap: '2rem' }}>
           <TextBox label="회사명">
-            <InputBox label="회사명" placeholder="회사명을 입력해주세요" value={info.company} disabled />
+            <InputBox label="회사명" placeholder="회사명을 입력해주세요" value={info?.company} disabled />
           </TextBox>
           <TextBox label="전화번호">
-            <InputBox label="전화번호" placeholder="연락처를 입력해주세요" value={info.phoneNumber} disabled />
+            <InputBox label="전화번호" placeholder="연락처를 입력해주세요" value={info?.phoneNumber} disabled />
             <Caption>{`회사명과 전화번호를 확인해 주세요`}</Caption>
           </TextBox>
         </div>
@@ -76,9 +79,10 @@ const Step명함인증 = () => {
           </BlueButton>
         </ButtonWrapper>
       </DoneWrapper>
-    );
+    </>
+  );
 
-  return !!info ? (
+  return mutation.isPending || !!info ? (
     <VerificationDone />
   ) : (
     <>

--- a/src/pages/onboarding/components/seniorOnboarding/Step졸업인증.tsx
+++ b/src/pages/onboarding/components/seniorOnboarding/Step졸업인증.tsx
@@ -7,6 +7,7 @@ import { FullBtn } from '@components/commons/FullButton';
 import { useNavigate } from 'react-router-dom';
 import { SuccessImg } from '@assets/images';
 import useOCRUnivQuery from '@pages/onboarding/hooks/useOCRUnivQuery';
+import Loading from '@components/commons/Loading';
 
 const Step졸업인증 = () => {
   const DEFAULT_TEXT = '졸업증명서를 첨부해 주세요';
@@ -49,6 +50,7 @@ const Step졸업인증 = () => {
 
   return (
     <>
+      {mutation.isPending && <Loading isTransparent />}
       <Wrapper>
         <div style={{ padding: '0 2rem' }}>
           <TextBox label="졸업증명서">


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #324 

## ✅ Done Task
- [x] 졸업증명서 OCR 로딩 스피너 추가 
- [x] 명함 사진 OCR 로딩 스피너 추가  

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->

우선 아래와 같은 이유로 기디에게 제안을 드렸고 오케이 해주신 디자인대로 작업 진행했습니다! 
<img width="838" alt="image" src="https://github.com/user-attachments/assets/632aa00a-fcf3-4f4f-94f7-16b64236f876">

3번 선택지로 구현하기 위해서 `어두운 배경 + 기존 스피너` 가 필요했는데요! 
기존 코드에서 최대한 수정 / 추가 작업 없이 어떻게 변형을 줄 수 있을까... 고민해봤는데 
원래 있던 **`Loading` 공통 컴포넌트를 살짝 확장**시켜주었습니다
```tsx
const Loading = ({ isTransparent = false }: { isTransparent?: boolean }) => {
```
이렇게 optional prop 하나를 추가해줬고, (default: false)
```tsx
<Wrapper $isTransparent={isTransparent}>
```
최상위 Wrapper에 스타일 컴포넌트 prop을 넘겨줘서
```ts
background-color: ${({ $isTransparent, theme }) =>
    $isTransparent ? theme.colors.transparentBlack_65 : theme.colors.grayScaleWhite};
```
이렇게 스타일컴포넌트에서 isTransparent 불리언값에 따라 
어두운반투명배경을 깔지 or 기존의 흰배경을 깔지 조건부 스타일링 되도록 수정했어요! 
당연히 optional이기 때문에 기존 로딩뷰가 사용된 모든 곳에는 지장 없고, 
앞으로 **모달이 뜨기 전까지 들어가야 하는 로딩뷰** 가 필요한 곳이 있다면, 아래와 같이 `isTransparent` 속성 넣어서 공컴 사용하시면 됩니당

```tsx
{mutation.isPending && <Loading isTransparent />}
```



## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->

https://github.com/user-attachments/assets/4ea66864-322d-4b90-8fd0-501031e89785

