### PR TITLE
[ Fix ] 후배 학교 메일 인증 API 변경사항 반영

### DIFF
--- a/src/pages/onboarding/apis/univAxios.ts
+++ b/src/pages/onboarding/apis/univAxios.ts
@@ -1,29 +1,21 @@
-import { axios } from "@utils/apis"
+import { axios } from '@utils/apis';
 
 export interface univVerifyPropType {
   email: string;
-  univName: string;
+  univName?: string;
   code?: string;
 }
 
 export const univVerifyAxios = ({ email, univName }: univVerifyPropType) => {
-  return axios.post(
-    '/api/v1/univ/verify',
-    {
-      email,
-      univName,
-    }
-  )
+  return axios.post('/api/v1/univ/verify', {
+    univName,
+    univMail: email,
+  });
 };
 
-
-export const univVerifycodeAxios = ({ email, univName, code }: univVerifyPropType) => {
-  return axios.post(
-    '/api/v1/univ/verifycode',
-    {
-      email,
-      univName,
-      code,
-    }
-  )
+export const univVerifycodeAxios = ({ email, code }: univVerifyPropType) => {
+  return axios.post('/api/v1/univ/verifycode', {
+    univEmail: email,
+    verificationCode: code,
+  });
 };

--- a/src/pages/onboarding/components/juniorOnboarding/Step이메일입력.tsx
+++ b/src/pages/onboarding/components/juniorOnboarding/Step이메일입력.tsx
@@ -99,7 +99,7 @@ const Step이메일입력 = () => {
 
   const handleClickButton = () => {
     verifycodeMutation.mutate(
-      { email, univName, code },
+      { email, code },
       {
         onSuccess: () => {
           setIsModalOpen(true);
@@ -110,7 +110,7 @@ const Step이메일입력 = () => {
         onError: () => {
           setIsValidCodeError(true);
         },
-      },
+      }
     );
   };
 

--- a/src/pages/onboarding/components/juniorOnboarding/Step이메일입력.tsx
+++ b/src/pages/onboarding/components/juniorOnboarding/Step이메일입력.tsx
@@ -84,6 +84,11 @@ const Step이메일입력 = () => {
     );
   };
 
+  const handleChangeEmail = (e: ChangeEvent<HTMLInputElement>) => {
+    setEmail(e.target.value);
+    setIsEmailError(false);
+  };
+
   const handleChangeCode = (e: ChangeEvent<HTMLInputElement>) => {
     const codeInput = e.target.value;
     setCode(codeInput);
@@ -127,7 +132,7 @@ const Step이메일입력 = () => {
               label="학교메일"
               placeholder="메일 주소를 입력해 주세요"
               value={email}
-              onChange={(e) => setEmail(e.target.value)}
+              onChange={handleChangeEmail}
               isError={isEmailError}>
               <InnerButton onClick={handleClickSend} text={isActive ? '재전송' : '인증번호 전송'} />
             </InputBox>

--- a/src/pages/onboarding/hooks/useUnivQuery.ts
+++ b/src/pages/onboarding/hooks/useUnivQuery.ts
@@ -1,24 +1,24 @@
-import { univVerifyAxios, univVerifycodeAxios, univVerifyPropType } from "@pages/onboarding/apis/univAxios";
-import { useMutation } from "@tanstack/react-query"
+import { univVerifyAxios, univVerifycodeAxios, univVerifyPropType } from '@pages/onboarding/apis/univAxios';
+import { useMutation } from '@tanstack/react-query';
 
 export const useUnivVerify = () => {
   const mutation = useMutation({
     mutationFn: ({ email, univName }: univVerifyPropType) => univVerifyAxios({ email, univName }),
     onError: (error) => {
-      console.log('phone verify post Error: ', error);
-    }
+      console.error('phone verify post Error: ', error);
+    },
   });
 
   return mutation;
-}
+};
 
 export const useUnivVerifycode = () => {
   const mutation = useMutation({
-    mutationFn: ({ email, univName, code }: univVerifyPropType) => univVerifycodeAxios({ email, univName, code }),
+    mutationFn: ({ email, code }: univVerifyPropType) => univVerifycodeAxios({ email, code }),
     onError: (error) => {
-      console.log('phone verifycode post Error: ', error);
-    }
+      console.error('phone verifycode post Error: ', error);
+    },
   });
 
   return mutation;
-}
+};


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #331 

## ✅ Done Task
  - [x] API 변경 사항 반영 
  - [x] 작동 테스트

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->
기존에 사용하던 Open API가 **한번 사용한 메일주소는 재사용하지 못하는 이슈**로 테스트환경에 매우 부적합했는데요,
그래서 서버 측에서 `학교명 - 학교메일주소도메인` 데이터를 DB에 직접 넣어서 검증하는 방식으로 API가 수정되었습니다 
그 과정에서 API 살짝 바뀌어서 해당 변경사항 반영해주었고, 
작업 후 학교 메일 인증 정상적으로 이루어지는지도 테스트 완료했습니다! (아래 영상 참고) 

이제 후배 온보딩 끝까지 갈 수 있다 ! 야호 ! 🎉 

## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->

https://github.com/user-attachments/assets/36f4017b-57f4-4764-85c0-676c4db52249

