### PR TITLE
[ Fix ] 모바일뷰 캘린더 하단바 안가려지게 수정

### DIFF
--- a/src/pages/juniorPromiseRequest/components/CalendarBottomSheet.tsx
+++ b/src/pages/juniorPromiseRequest/components/CalendarBottomSheet.tsx
@@ -121,8 +121,7 @@ const BottomSheetWrapper = styled.div<{ $isCalendarOpen: boolean }>`
   z-index: 4;
 
   width: 100%;
-  height: auto;
-  min-height: 100dvh;
+  height: 100dvh;
   padding: 3.8rem 0 0;
   border-radius: 16px 16px 0 0;
 

--- a/src/pages/juniorPromiseRequest/components/CalendarBottomSheet.tsx
+++ b/src/pages/juniorPromiseRequest/components/CalendarBottomSheet.tsx
@@ -103,12 +103,12 @@ const Background = styled.div<{ $isCalendarOpen: boolean }>`
   left: 50%;
   z-index: 2;
 
-  transform: translate(-50%, -50%);
-
   width: 100%;
   height: 100dvh;
 
   background: ${({ theme }) => theme.colors.transparentBlack_65};
+
+  transform: translate(-50%, -50%);
 `;
 
 const BottomSheetWrapper = styled.div<{ $isCalendarOpen: boolean }>`
@@ -121,7 +121,8 @@ const BottomSheetWrapper = styled.div<{ $isCalendarOpen: boolean }>`
   z-index: 4;
 
   width: 100%;
-  height: 100vh;
+  height: auto;
+  min-height: 100dvh;
   padding: 3.8rem 0 0;
   border-radius: 16px 16px 0 0;
 


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #334 

## ✅ Done Task
  - [x] 모바일뷰 캘린더 하단바 안가려지게 수정

## ☀️ New-insight
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->
크롬과 사파리 모두 특정 버전 이후부터는 스크롤 시 주소창과 하단 바가 자동으로 숨겨지는 기능을 가지고 있었습니다.!
모바일 웹 스크롤 시 하단바에 가려지던 바텀바가 가려지지 않도록 수정했습니다.
height : 100vh 대신  height : auto 와 min-height: 100dvh를 사용해서,
전체화면으로 스크롤되도록 하여 해결했습니다!


## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->
### 모바일뷰 테스트
- 하단바 있을 경우
![IMG_2084](https://github.com/user-attachments/assets/ec3c5526-11bc-4f02-8de9-9eb6803194a1)

- 하단바 없을 경우
![IMG_2085](https://github.com/user-attachments/assets/b8937f03-5748-431f-b5b3-c93191014f99)


