### PR TITLE
[ Fix ] 약속 리스트 후배일 경우 뒤로가기 탭 남아있도록 하기

### DIFF
--- a/src/components/commons/Nav.tsx
+++ b/src/components/commons/Nav.tsx
@@ -94,6 +94,7 @@ const TapContent = styled.span<{ $isActive: boolean }>`
   width: fit-content;
 
   color: ${({ theme, $isActive }) => ($isActive ? theme.colors.grayScaleBG : theme.colors.grayScaleMG1)};
+
   ${({ theme }) => theme.fonts.navigation};
 `;
 

--- a/src/pages/promiseDetail/PromiseDetailPageJunior.tsx
+++ b/src/pages/promiseDetail/PromiseDetailPageJunior.tsx
@@ -80,7 +80,17 @@ const PromiseDetailPageJunior = () => {
         </>
       ) : (
         <>
-          <Header LeftSvg={ArrowLeftIc} title="내가 보낸 약속" onClickLeft={() => navigate('/promiseList')} />
+          <Header
+            LeftSvg={ArrowLeftIc}
+            title="내가 보낸 약속"
+            onClickLeft={() =>
+              navigate(`/promiseList`, {
+                state: {
+                  prevTap: tap,
+                },
+              })
+            }
+          />
           <Divider />
           <Wrapper>
             <Layout>

--- a/src/pages/promiseList/components/PromiseTap.tsx
+++ b/src/pages/promiseList/components/PromiseTap.tsx
@@ -137,6 +137,8 @@ const TapContainer = styled.div`
 const TapText = styled.span<{ $isActive: boolean }>`
   ${({ theme }) => theme.fonts.Title1_SB_16};
   color: ${({ theme, $isActive }) => ($isActive ? theme.colors.grayScaleBG : theme.colors.grayScaleMG2)};
+
+  cursor: pointer;
 `;
 
 const ProfileWrapper = styled.div`


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #308 

## ✅ Done Task
  - [x] 약속 리스트 후배일 경우 뒤로가기 탭 남아있도록 하기

## ☀️ New-insight
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->
[지난번에 작업한 내용인데요](https://github.com/TEAM-SEONYAK/SEONYAK_CLIENT/pull/269)
선배일 경우만 남아있도록 작업해두고 후배일 경우에는 작업을 안해뒀길래 해당 부분 추가해두었습니다!

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->

## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->

[이전]

https://github.com/user-attachments/assets/d3f1d8f5-56ed-4a3c-bee0-61879d7f50e2

[이후]

https://github.com/user-attachments/assets/3cdf0f25-0fa0-44dd-8b88-af5607c676f2

