### PR TITLE
[ Fix ] junior promise page QA 반영

### DIFF
--- a/src/components/commons/SeniorCard.tsx
+++ b/src/components/commons/SeniorCard.tsx
@@ -69,6 +69,8 @@ const SeniorCardWrapper = styled.div<{ $isSmall: boolean }>`
   border-radius: 8px;
 
   background: ${({ theme }) => theme.colors.grayScaleWhite};
+
+  cursor: pointer;
 `;
 const SeniorImg = styled.img<{ $isSmall: boolean }>`
   width: ${({ $isSmall }) => ($isSmall ? '8.8rem' : '11.4rem')};

--- a/src/pages/juniorPromise/JuniorPromisePage.tsx
+++ b/src/pages/juniorPromise/JuniorPromisePage.tsx
@@ -1,5 +1,8 @@
-import { ArrowLeftIc } from '@assets/svgs';
+import { HeaderLogoIc, AlarmIc } from '@assets/svgs';
 import { Header } from '@components/commons/Header';
+import { AutoCloseModal } from '@components/commons/modal/AutoCloseModal';
+import img_modal_accept from '@assets/images/img_modal_accept.png';
+
 import Nav from '@components/commons/Nav';
 import { SeniorCard } from '@components/commons/SeniorCard';
 import styled from '@emotion/styled';
@@ -17,6 +20,8 @@ import { useNavigate } from 'react-router-dom';
 import useSeniorProfileQueries from '@hooks/seniorProfileQueries';
 
 const JuniorPromisePage = () => {
+  const [showModal, setShowModal] = useState(false);
+
   const navigate = useNavigate();
 
   // 바텀 시트 내 버튼& 내용 필터 버튼
@@ -113,11 +118,12 @@ const JuniorPromisePage = () => {
       {isSeniorCardClicked ? (
         <>
           <Header
-            LeftSvg={ArrowLeftIc}
-            onClickLeft={() => {
-              setIsSeniorCardClicked(false);
-            }}
+            LeftSvg={HeaderLogoIc}
+            RightSvg={AlarmIc}
+            onClickRight={() => setShowModal(true)}
+            bgColor="transparent"
           />
+
           <PreView variant="secondary" seniorId={seniorId + ''} />
           <FullBtn text="약속 신청하기" onClick={handlePromiseClicked} />
         </>
@@ -151,6 +157,13 @@ const JuniorPromisePage = () => {
           <Nav />
         </PreventScroll>
       )}
+      {/* 모달 컴포넌트 추가 */}
+      <AutoCloseModal
+        text="알림은 문자를 확인해주세요 !"
+        showModal={showModal}
+        handleShowModal={(show: boolean) => setShowModal(show)}>
+        <ModalImg src={img_modal_accept} />
+      </AutoCloseModal>
     </>
   );
 };
@@ -186,4 +199,8 @@ const SeniorCardListLayout = styled.div`
   height: 100%;
   margin-bottom: 10rem;
   padding: 0.8rem 2rem;
+`;
+const ModalImg = styled.img`
+  width: 27rem;
+  height: 17.2rem;
 `;

--- a/src/pages/juniorPromise/components/BottomSheet.tsx
+++ b/src/pages/juniorPromise/components/BottomSheet.tsx
@@ -142,6 +142,10 @@ const Content = styled.div`
   overflow: auto;
 
   height: 35.2rem;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
 const FieldLayout = styled.div`

--- a/src/pages/juniorPromise/components/BottomSheet.tsx
+++ b/src/pages/juniorPromise/components/BottomSheet.tsx
@@ -219,4 +219,7 @@ const ExitBottomSheet = styled.button<SelectedChipListProps>`
 
   color: ${({ theme }) => theme.colors.grayScaleWhite};
   ${({ theme }) => theme.fonts.Head2_SB_18};
+
+  cursor: ${({ $chipFieldName, $chipPositionName }) =>
+    $chipFieldName.length > 0 || $chipPositionName.length > 0 ? 'pointer' : 'default'};
 `;

--- a/src/pages/juniorPromise/components/FieldList.tsx
+++ b/src/pages/juniorPromise/components/FieldList.tsx
@@ -29,6 +29,8 @@ const FieldWrapper = styled.div`
   justify-content: space-between;
 
   padding: 1rem 0;
+
+  cursor: pointer;
 `;
 const FieldTitle = styled.p<{ isSelected: boolean }>`
   ${({ theme }) => theme.fonts.Title1_SB_16};

--- a/src/pages/juniorPromise/components/PositionList.tsx
+++ b/src/pages/juniorPromise/components/PositionList.tsx
@@ -39,4 +39,6 @@ const PositionTitle = styled.p<{ $selectedPositionIndex: boolean }>`
   ${({ theme }) => theme.fonts.Caption2_SB_12};
   color: ${({ theme, $selectedPositionIndex }) =>
     $selectedPositionIndex ? theme.colors.Blue : theme.colors.grayScaleDG};
+
+  cursor: pointer;
 `;

--- a/src/pages/juniorPromise/components/SeniorSearch.tsx
+++ b/src/pages/juniorPromise/components/SeniorSearch.tsx
@@ -55,23 +55,23 @@ export const SeniorSearch = (props: SeniorSearchPropTypes) => {
           <LineWrapper>
             <Line292Ic />
           </LineWrapper>
-          <StyledResetIc onClick={handleReset} />
+          <ResetIcon onClick={handleReset} />
         </BtnLayout>
         <SelectedChipList $chipFieldName={chipFieldName} $chipPositionName={chipPositionName}>
           {chipFieldName.map((field, fieldId) => (
             <Chip key={fieldId}>
               {field}
-              <CloseButton onClick={() => handleDeleteFieldChip(field)}>
+              <CloseIcon onClick={() => handleDeleteFieldChip(field)}>
                 <CloseIc />
-              </CloseButton>
+              </CloseIcon>
             </Chip>
           ))}
           {chipPositionName.map((position, positionId) => (
             <Chip key={positionId}>
               {position}
-              <CloseButton onClick={() => handleDeletePositionChip(position)}>
+              <CloseIcon onClick={() => handleDeletePositionChip(position)}>
                 <CloseIc />
-              </CloseButton>
+              </CloseIcon>
             </Chip>
           ))}
         </SelectedChipList>
@@ -136,7 +136,7 @@ const Chip = styled.div`
   color: ${({ theme }) => theme.colors.grayScaleDG};
 `;
 
-const CloseButton = styled(CloseIc)`
+const CloseIcon = styled(CloseIc)`
   padding: 0.4962rem 0.4839rem 0.4962rem 0.5084rem;
 
   cursor: pointer;
@@ -146,6 +146,6 @@ const LineWrapper = styled.div`
   padding-left: 13.7rem;
 `;
 
-const StyledResetIc = styled(ResetIc)`
+const ResetIcon = styled(ResetIc)`
   cursor: pointer;
 `;

--- a/src/pages/juniorPromise/components/SeniorSearch.tsx
+++ b/src/pages/juniorPromise/components/SeniorSearch.tsx
@@ -55,7 +55,7 @@ export const SeniorSearch = (props: SeniorSearchPropTypes) => {
           <LineWrapper>
             <Line292Ic />
           </LineWrapper>
-          <ResetIc onClick={handleReset} />
+          <StyledResetIc onClick={handleReset} />
         </BtnLayout>
         <SelectedChipList $chipFieldName={chipFieldName} $chipPositionName={chipPositionName}>
           {chipFieldName.map((field, fieldId) => (
@@ -138,8 +138,14 @@ const Chip = styled.div`
 
 const CloseButton = styled(CloseIc)`
   padding: 0.4962rem 0.4839rem 0.4962rem 0.5084rem;
+
+  cursor: pointer;
 `;
 
 const LineWrapper = styled.div`
   padding-left: 13.7rem;
+`;
+
+const StyledResetIc = styled(ResetIc)`
+  cursor: pointer;
 `;

--- a/src/pages/juniorPromise/components/seniorFilter/Banner.tsx
+++ b/src/pages/juniorPromise/components/seniorFilter/Banner.tsx
@@ -2,19 +2,30 @@ import styled from '@emotion/styled';
 import { Header } from '@components/commons/Header';
 import { HeaderLogoIc, AlarmIc } from '@assets/svgs';
 import img_hbhome_main from '@assets/images/img_hbhome_main.png';
+import { useState } from 'react';
+import { AutoCloseModal } from '@components/commons/modal/AutoCloseModal';
+import img_modal_accept from '@assets/images/img_modal_accept.png';
+
 interface BannerPropTypes {
-  // 오류시 '후배'
   myNickname: string | undefined;
 }
 
 export const Banner = ({ myNickname }: BannerPropTypes) => {
+  const [showModal, setShowModal] = useState(false);
+
   return (
     <>
-      <Header LeftSvg={HeaderLogoIc} RightSvg={AlarmIc} bgColor="transparent" />
+      <Header LeftSvg={HeaderLogoIc} RightSvg={AlarmIc} onClickRight={() => setShowModal(true)} bgColor="transparent" />
       <Background>
         <HbHomeMainImg src={img_hbhome_main} />
       </Background>
       <Title>반가워요 {myNickname ? myNickname : '후배'}님,고민을 해결해볼까요?</Title>
+      <AutoCloseModal
+        text="알림은 문자를 확인해주세요 !"
+        showModal={showModal}
+        handleShowModal={(show: boolean) => setShowModal(show)}>
+        <ModalImg src={img_modal_accept} />
+      </AutoCloseModal>
     </>
   );
 };
@@ -45,4 +56,9 @@ const HbHomeMainImg = styled.img`
   position: absolute;
   right: 0;
   bottom: 0;
+`;
+
+const ModalImg = styled.img`
+  width: 27rem;
+  height: 17.2rem;
 `;


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #338 

## ✅ Done Task
- [x] 바텀시트 클릭됐을때만 '적용할래요'버튼 커서 포인터 적용
- [x] 클릭 가능한 모든 것 커서 포인터 적용
- [x] 스크롤바 보이는 거 삭제 
- [x] 바뀐 헤더 적용

언제나 정신 똑바로 차리고 살아야 합니다..
헤더를 수정해도 반응조차 없길래.. 억장이 무너져 내렸는데 알고보니 지은이 뷰랑 연결된 헤더만 열심히 수정하고
확인은 제 뷰에서 했으니.. 얼마나 바보같은 짓을 하고 있었는지.. 
📢 지은이에게
하는김에 지은이 뷰 헤더도 수정했는데 피그마 상에 지은이 뷰는 헤더가 없더라구요?? 조건부 렌더링에는 지은이가 헤더를 해두었길래
일단 "transparent"헤더로 해두었는데.. 지은이 한 번 확인 부탁드림다~ (그래서 지은이 소환했어요)


## 💎 PR Point
커밋 순서대로, 커서 포인터 적용했구(적용할래요 버튼 색 들어오는 경우에만 커서포인터 수정했습니다),
바텀시트 직무부분 스크롤 안보이게 수정완료했습니다!
바뀐 헤더대로 수정 해두었습니다.

## 📸 Screenshot
- 커서포인터

https://github.com/user-attachments/assets/43a9a921-baf1-4453-96e2-37d3d6c52309



- 스크롤 수정

https://github.com/user-attachments/assets/299cabc9-6ec9-422d-8fff-4e3f0de587eb




- 바뀐 헤더

https://github.com/user-attachments/assets/ae1f767f-2c37-484a-90ab-56738f681907

