### PR TITLE
[ Feat ] 닉네임 조건 체크 가시화 

### DIFF
--- a/src/pages/onboarding/components/commonOnboarding/Step개인정보입력.tsx
+++ b/src/pages/onboarding/components/commonOnboarding/Step개인정보입력.tsx
@@ -44,6 +44,12 @@ const Step개인정보입력 = () => {
   };
 
   const handleCheckNickname = () => {
+    // 닉네임 조건 체크
+    const regExp = /^[ㄱ-ㅎ가-힣a-zA-Z0-9]+$/;
+    if (!regExp.test(nickname)) {
+      setNicknameStatus('INVALID');
+      return;
+    }
     mutation.mutate(nickname, {
       onSuccess: () => {
         setNicknameStatus('VALID');

--- a/src/pages/onboarding/components/commonOnboarding/Step개인정보입력.tsx
+++ b/src/pages/onboarding/components/commonOnboarding/Step개인정보입력.tsx
@@ -90,6 +90,7 @@ const Step개인정보입력 = () => {
             placeholder="닉네임을 입력해 주세요"
             isError={nicknameStatus === 'INVALID' || nicknameStatus === 'CONFLICT'}
             value={nickname}
+            maxLength={8}
             onChange={handleChangeInput}>
             <InnerButton text="중복확인" onClick={handleCheckNickname} />
           </InputBox>


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #343 

## ✅ Done Task
  - [x] 8자 제한 추가 
  - [x] 조건 체크 가시화 

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->

### 조건 체크 정규식 추가 
특수 문자/기호 제외하는 것보다 **한글/영어/숫자만 허용**하는게 더 적합할 것 같아서 해당 정규식으로 검사하는 코드를 중복체크 버튼 클릭 핸들러에 추가해줬어요

이상적인 방법이라면 input에 `pattern`속성으로 정규식 넣어주고, `중복체크` 버튼을 `input type=submit` 으로 구현해주면 좋은데, 
현재 innerbutton을 공통 컴포넌트를 쓰고 있어서 건드리기 번거로운 구조더라구요
그래서 그냥 간단하게 핸들러에 로직 추가해줬고, 서진언니가 말해준 것처럼 서버에서 조건 체크 하기 **전**에 클라에서 먼저 쳐내는 방식으로 구현하도록, 클라에서 검사했을 때 **조건불충족 되면 서버통신도 요청하지 않도록** 해줬어요! 

```ts
// 중복체크 버튼 클릭 핸들러 함수
  const regExp = /^[ㄱ-ㅎ가-힣a-zA-Z0-9]+$/;
  if (!regExp.test(nickname)) {
    setNicknameStatus('INVALID');
    return;
  }
```
## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->

영상 보시면 중복체크 시 **서버통신 없이** 조건체크되는거 확인 가능합니다! 

https://github.com/user-attachments/assets/31bf6ebc-7f19-422c-81f7-0b9452dd06bd


