### PR TITLE
[ Fix ] 온보딩 QA

### DIFF
--- a/src/pages/onboarding/components/commonOnboarding/Step약관동의.tsx
+++ b/src/pages/onboarding/components/commonOnboarding/Step약관동의.tsx
@@ -44,8 +44,8 @@ const Step약관동의 = () => {
         <Line />
         {약관_LIST.map(({ text, link }, idx) => (
           <li key={text}>
-            <ItemWrapper type="button" onClick={() => handleClickCheck(idx)}>
-              <ItemLeftWrapper>
+            <ItemWrapper type="button">
+              <ItemLeftWrapper onClick={() => handleClickCheck(idx)}>
                 <IconWrapper $isChecked={agreement[idx]}>
                   <CheckItemIc />
                 </IconWrapper>

--- a/src/pages/onboarding/components/commonOnboarding/Step학과선택.tsx
+++ b/src/pages/onboarding/components/commonOnboarding/Step학과선택.tsx
@@ -117,7 +117,6 @@ const Wrapper = styled.main`
   display: flex;
   flex-direction: column;
 
-  height: 100dvh;
   padding-top: 2rem;
 `;
 


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #347 

## ✅ Done Task
  - [x] 약관동의 클릭하고 오면 풀림 해결
  - [x] 스크롤 영역 나오는거 해결

## 💎 PR Point
- 약관 동의
기존 약관동의하는 `onClick`함수가 약관 상세보기를 포함한 태그 `ItemWrapper`에 달려있어 약관동의 상세를 누르면 `onClick`함수가 한번 더 적용되어 약관이 풀렸던 것이었습니다! 바로 하위의 `ItemLeftWrapper` 에 다는 것으로 변경하여 약관 풀림 현상 해결했습니다.
하지만 이렇게 되면 체크표시부터 글자 영역을 클릭할때만  동의가 되는데 (오른쪽 여백 클릭시 무반응, 약관상세 클릭시 약관이동) 이것에 대해 어떻게 생각하시는지 궁금합니다

- 스크롤 영역 확인
학과 렌더링 되는 부분 `Container`상위의  `Wrapper` 높이 속성 제거하여 해결했습니다!




## 📸 Screenshot
- 약관동의 해결

https://github.com/user-attachments/assets/486d60ed-1c21-4ebd-adbc-445cfc216747



- 학과 외부 스크롤 해


https://github.com/user-attachments/assets/869db7a0-6931-4b1c-a5f8-c8ad84844067


