### PR TITLE
[ Fix ] 이미지 미업로드 시 빈문자열로 처리하도록 수정 

### DIFF
--- a/src/pages/onboarding/components/commonOnboarding/Step개인정보입력.tsx
+++ b/src/pages/onboarding/components/commonOnboarding/Step개인정보입력.tsx
@@ -57,12 +57,13 @@ const Step개인정보입력 = () => {
   };
 
   const handleClickLink = () => {
-    if (!res || !imageFile) return;
-    imageUploadMutate({ url: res.url, image: imageFile });
+    if (res && imageFile) {
+      imageUploadMutate({ url: res.url, image: imageFile });
+    }
     setData((prev) => ({
       ...prev,
       imageFile,
-      image: res.fileName,
+      image: imageFile ? res.fileName : '',
       nickname: nickname,
       isNicknameValid: true,
     }));

--- a/src/pages/onboarding/type.ts
+++ b/src/pages/onboarding/type.ts
@@ -14,7 +14,7 @@ export interface JoinPropType {
   nickname: string;
   isNicknameValid?: boolean;
   image: string;
-  imageFile?: File;
+  imageFile?: File | null;
   phoneNumber: string;
   univName: string;
   field: string;


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #345 

## ✅ Done Task
- [x] 이미지 미선택 시 빈문자열로 데이터 처리 
- [x] 이미지 선택하지 않아도 다음단계 넘어갈 수 있도록 수정 


## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->

프로필 이미지를 선택하지 않아도 가입이 진행될 수 있도록 로직을 수정해주었습니다! 

https://github.com/TEAM-SEONYAK/SEONYAK_CLIENT/blob/ae9700f0b1ed1966aa5aae3d95a99f658b83aece/src/pages/onboarding/components/commonOnboarding/Step%EA%B0%9C%EC%9D%B8%EC%A0%95%EB%B3%B4%EC%9E%85%EB%A0%A5.tsx#L59-L71

기존에는 이미지를 첨부하지 않았을 경우 (imageFile state가 비어있을 경우) 이벤트 핸들러에서 early return을 시켜버려서 다음단계로의 이동을 막았었는데요! 
다음과 같이 바꿨습니다. 
- `imageUploadMutate` (presignedURL을 통해 프로필이미지를 S3로 업로드하는 함수) : 이미지를 첨부했을 때만 실행 
- 회원가입 요청 시에 request body로 쓰는 data state에서 
  - `image` : 이미지 파일이 **있는** 경우는 s3에 업로드된 **파일명**, **없는** 경우는 **빈 문자열**을 담아서 보냅니다 

> request body에서 Image 필드가 필수 옵션이므로 (반드시 문자열로 보내야함) 빈 문자열 처리 해주었어용 







## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->

https://github.com/user-attachments/assets/c42a823d-2f60-4a82-8013-260fcb13010a

