### PR TITLE
[ Fix ] 에러페이지 홈으로 클릭시 이동 변경사항 반영 

### DIFF
--- a/src/pages/errorPage/ErrorPage.tsx
+++ b/src/pages/errorPage/ErrorPage.tsx
@@ -12,8 +12,20 @@ const ErrorPage = () => {
   const navigate = useNavigate();
 
   const handleHomeBtn = () => {
-    localStorage.clear();
-    navigate('/');
+    const token = localStorage.getItem('seonyakToken');
+    const role = localStorage.getItem('seonyakRole');
+
+    if (!token || !role) {
+      localStorage.clear();
+      return navigate('/');
+    }
+
+    const routeMap: { [key: string]: string } = {
+      SENIOR: '/promiseList',
+      JUNIOR: '/juniorPromise',
+    };
+
+    navigate(routeMap[role] || '/');
   };
 
   const handleOpenUrl = (url: string) => window.open(url);


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #321 

## ✅ Done Task
  - [x] 홈으로 클릭시 토큰, 롤 유무 롤에따라 이동페이지 변경

## 💎 PR Point
1️⃣ 토큰이랑 롤 둘다 있는데 에러
- 선배일 경우 -> promiseList
- 후배일 경우 -> juniorPromise

2️⃣ 토큰 또는 롤 없어서 에러났다 
-> 로그인페이지로(기존과 동일: 로컬스토리지 비우고 루트로 이동)


## 📸 Screenshot
`juniorPromise` api 망가뜨리고 후배계정으로 테스트 해본 거라 임시방편으로 영상찍을때는 이동주소 `promiseList`로 해놓고 테스트 한 영상입니다! 코드는 다시 `juniorPromise`로 잘 되어있습니다! 

- 토큰, 롤 둘 다 있는 경우

https://github.com/user-attachments/assets/1c36f891-a5b3-40f2-afe8-a9192f411bfe


- 토큰 없는 경우

https://github.com/user-attachments/assets/974264ee-0bca-4cff-8d70-920496f8f330




- 롤 없는 경우

https://github.com/user-attachments/assets/2f48304f-c250-4f66-9bac-7ae5a541918a

