### PR TITLE
[ Feat ] 타이머 종료되면 입력 필드 초기화

### DIFF
--- a/src/pages/onboarding/components/commonOnboarding/Step번호입력.tsx
+++ b/src/pages/onboarding/components/commonOnboarding/Step번호입력.tsx
@@ -61,6 +61,7 @@ const Step번호입력 = () => {
         if (prevTime <= 1000) {
           clearInterval(id);
           setIsActive(false);
+          setVerificationCode('');
           return 0;
         }
         return prevTime - 1000;


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #351

## ✅ Done Task
  - [x] 타이머 종료되면 입력 필드 초기화

## ☀️ New-insight
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->

## 💎 PR Point
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->
타이머의 남은 시간이 1초 이하가 되어 입력 필드 창이 닫힐 때, setVerificationCode를 초기값인 ''로 설정했습니다.
따라서 재전송 버튼을 눌러 입력 필드 창이 다시 열리더라도 초기화된 상태로 표시됩니다.


## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->

https://github.com/user-attachments/assets/d2b78bd2-51a5-40fc-9511-32ec13073582
