### PR TITLE
[ Fix ] 온보딩 완료 후 이탈한 선배 대비 SENIOR_PENDING 추가 반영

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -95,7 +95,7 @@ const router = createBrowserRouter([
       },
       {
         path: 'seniorOnboarding',
-        element: <Layout userRole="SENIOR" />,
+        element: <Layout userRole="SENIOR_PENDING" />,
         children: [
           {
             index: true,

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -9,7 +9,12 @@ const HomePage = () => {
 
   useEffect(() => {
     if (token && role) {
-      navigate(role === 'SENIOR' ? '/promiseList' : '/juniorPromise');
+      // 온보딩 완료 후 이탈한 선배 (프로필 등록 안 한 선배)
+      if (role === 'SENIOR_PENDING') {
+        navigate('/seniorProfile');
+      } else {
+        navigate(role === 'SENIOR' ? '/promiseList' : '/juniorPromise');
+      }
     } else {
       navigate('/join');
     }

--- a/src/pages/join/components/Button.tsx
+++ b/src/pages/join/components/Button.tsx
@@ -5,7 +5,7 @@ import { useNavigate } from 'react-router-dom';
 const JoinButton = () => {
   const navigate = useNavigate();
   const handleSeniorClick = () => {
-    navigate('/signup', { state: { role: 'SENIOR' } });
+    navigate('/signup', { state: { role: 'SENIOR_PENDING' } });
   };
 
   const handleJuniorClick = () => {

--- a/src/pages/juniorPromiseRequest/hooks/queries.ts
+++ b/src/pages/juniorPromiseRequest/hooks/queries.ts
@@ -24,9 +24,10 @@ export const usePostAppointment = (onSuccess?: () => void, onError?: (error: str
   });
 };
 
-export const useSeniorTimeQuery = (seniorId: number) => {
+export const useSeniorTimeQuery = (seniorId: number, isJuniorRequest: boolean) => {
   return useQuery({
     queryKey: [QUERY_KEYS.getSeniorTime, seniorId],
     queryFn: () => getSeniorTimeAxios(seniorId),
+    enabled: !!isJuniorRequest,
   });
 };

--- a/src/pages/login/SignupPage.tsx
+++ b/src/pages/login/SignupPage.tsx
@@ -9,11 +9,11 @@ import { JoinHbBgSvg, JoinSbBgSvg } from '@assets/svgs';
 
 const SignupPage = () => {
   const role = useLocation().state.role;
-  const isSenior = role === 'SENIOR';
+  const isSenior = role === 'SENIOR_PENDING';
 
   return (
     <>
-      {role === 'SENIOR' ? <JoinSbBgSvgIcon /> : <JoinHbBgSvgIcon />}
+      {isSenior ? <JoinSbBgSvgIcon /> : <JoinHbBgSvgIcon />}
       <SignUpContainer>
         <DescTextWrapper>
           <MetaText>반가워요!</MetaText>
@@ -35,7 +35,7 @@ const SignupPage = () => {
             </>
           )}
         </DescTextWrapper>
-        {role === 'SENIOR' ? <OnboardingSBImg src={img_onboardingSB} /> : <OnboardingHBImg src={img_onboardingHB} />}
+        {isSenior ? <OnboardingSBImg src={img_onboardingSB} /> : <OnboardingHBImg src={img_onboardingHB} />}
         <BtnContainer onClick={() => googleLogin(role)}>
           <GoogleLogoImg src={ic_google_logo} />
           <Text>구글로 시작하기</Text>

--- a/src/pages/login/hooks/useGoogleLoginMutation.ts
+++ b/src/pages/login/hooks/useGoogleLoginMutation.ts
@@ -1,7 +1,7 @@
 import { useMutation } from '@tanstack/react-query';
 import { loginAxios } from '../apis/loginAxios';
 import { useNavigate } from 'react-router-dom';
-import { clearStorage, setRole, setToken } from '@utils/storage';
+import { clearStorage, setRole, setToken, setSeniorNickname } from '@utils/storage';
 
 interface useGoogleLoginPropType {
   role?: string;
@@ -14,15 +14,27 @@ const useGoogleLoginMutation = ({ role }: useGoogleLoginPropType) => {
       setToken(data.data.data.accessToken);
 
       const responseRole = data.data.data.role;
+
+      // 로그인 (이미 가입된 회원)
+      // 서버에서 받아오는 role
       if (responseRole) {
-        // 로그인 (이미 가입된 회원)
         setRole(responseRole);
-        navigate(responseRole === 'SENIOR' ? '/promiseList' : '/juniorPromise');
-      } else if (role) {
+        // 온보딩 완료 후 이탈한 선배 경우
+        if (responseRole === 'SENIOR_PENDING') {
+          setSeniorNickname(data.data.data.nickname);
+          navigate('/seniorProfile');
+        // 가입 완료된 경우
+        } else {
+          navigate(responseRole === 'SENIOR' ? '/promiseList' : '/juniorPromise');
+        }
+
         // 회원가입
-        navigate(role === 'SENIOR' ? '/seniorOnboarding' : '/juniorOnboarding');
-      } else {
+        // join 페이지에서 navigation state로 받아온 role
+      } else if (role) {
+        navigate(role === 'SENIOR_PENDING' ? '/seniorOnboarding' : '/juniorOnboarding');
+
         // 존재하지 않는 계정으로 로그인을 시도했을 경우
+      } else {
         console.error('🔴 존재하지 않는 계정');
         alert('존재하지 않는 계정이예요. 회원가입을 진행해주세요.');
         navigate('/');

--- a/src/pages/login/utils/googleLogin.ts
+++ b/src/pages/login/utils/googleLogin.ts
@@ -1,4 +1,4 @@
-const googleLogin = (role?: 'SENIOR' | 'JUNIOR') => {
+const googleLogin = (role?: 'SENIOR' | 'JUNIOR' | 'SENIOR_PENDING') => {
   window.location.href = `https://accounts.google.com/o/oauth2/v2/auth?${role ? `state=${role}&` : ''}client_id=${import.meta.env.VITE_APP_GOOGLE_CLIENT_ID}&redirect_uri=${import.meta.env.VITE_APP_GOOGLE_AUTH_REDIRECT_URI}&response_type=code&scope=email`;
 };
 

--- a/src/pages/onboarding/components/Layout.tsx
+++ b/src/pages/onboarding/components/Layout.tsx
@@ -9,11 +9,11 @@ import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { useEffect, useState } from 'react';
 import { JoinPropType } from '../type';
 
-const Layout = ({ userRole }: { userRole: 'SENIOR' | 'JUNIOR' }) => {
+const Layout = ({ userRole }: { userRole: 'JUNIOR' | 'SENIOR_PENDING' }) => {
   const location = useLocation();
   const navigate = useNavigate();
   const step = +location.pathname.slice(18);
-  const onboardingStep = userRole === 'SENIOR' ? SENIOR_ONBOARDING_STEPS : JUNIOR_ONBOARDING_STEPS;
+  const onboardingStep = userRole === 'SENIOR_PENDING' ? SENIOR_ONBOARDING_STEPS : JUNIOR_ONBOARDING_STEPS;
   const { title, description } = onboardingStep[step ? step - 1 : 0];
   const GROUP_STEP = convertToGroupStep(userRole, step);
 
@@ -31,7 +31,7 @@ const Layout = ({ userRole }: { userRole: 'SENIOR' | 'JUNIOR' }) => {
   useEffect(() => {
     // 리로드 시 1단계로 back
     if (location.pathname.slice(-1) !== '1') {
-      userRole === 'SENIOR' ? navigate('/seniorOnboarding/1') : navigate('/juniorOnboarding/1');
+      userRole === 'SENIOR_PENDING' ? navigate('/seniorOnboarding/1') : navigate('/juniorOnboarding/1');
     }
   }, []);
 
@@ -45,7 +45,7 @@ const Layout = ({ userRole }: { userRole: 'SENIOR' | 'JUNIOR' }) => {
           step === 1 ? navigate('/') : navigate(-1);
         }}
       />
-      <ProgressBar max={userRole === 'SENIOR' ? 4 : 3} current={GROUP_STEP} />
+      <ProgressBar max={userRole === 'SENIOR_PENDING' ? 4 : 3} current={GROUP_STEP} />
       <MetaContainer>
         <TitleBox title={title} description={description} />
       </MetaContainer>

--- a/src/pages/onboarding/hooks/useJoinQuery.ts
+++ b/src/pages/onboarding/hooks/useJoinQuery.ts
@@ -1,13 +1,14 @@
 import { useMutation } from '@tanstack/react-query';
 import { joinAxios } from '../apis/joinAxios';
 import { JoinPropType } from '../type';
-import { setRole } from '@utils/storage';
+import { setRole, setSeniorId } from '@utils/storage';
 
 const useJoinQuery = () => {
   const mutation = useMutation({
     mutationFn: (requestBody: JoinPropType) => joinAxios(requestBody),
     onSuccess: (data) => {
       setRole(data.data.data.role);
+      setSeniorId(data.data.data.seniorId + '');
     },
     onError: (error) => {
       console.log('🔴 join patch Error: ', error);

--- a/src/pages/onboarding/hooks/useJoinQuery.ts
+++ b/src/pages/onboarding/hooks/useJoinQuery.ts
@@ -7,7 +7,7 @@ const useJoinQuery = () => {
   const mutation = useMutation({
     mutationFn: (requestBody: JoinPropType) => joinAxios(requestBody),
     onSuccess: (data) => {
-      setRole(data.data.data.userType);
+      setRole(data.data.data.role);
     },
     onError: (error) => {
       console.log('🔴 join patch Error: ', error);

--- a/src/pages/onboarding/type.ts
+++ b/src/pages/onboarding/type.ts
@@ -9,7 +9,7 @@ export interface BizInfoType {
 }
 
 export interface JoinPropType {
-  role: 'SENIOR' | 'JUNIOR';
+  role: 'SENIOR' | 'JUNIOR' | 'SENIOR_PENDING';
   isSubscribed: boolean[];
   nickname: string;
   isNicknameValid?: boolean;

--- a/src/pages/onboarding/utils/convertToGroupStep.ts
+++ b/src/pages/onboarding/utils/convertToGroupStep.ts
@@ -1,5 +1,5 @@
-const convertToGroupStep = (role: 'SENIOR' | 'JUNIOR', step: number): number => {
-  if (role === 'SENIOR') {
+const convertToGroupStep = (role: 'JUNIOR' | 'SENIOR_PENDING', step: number): number => {
+  if (role === 'SENIOR_PENDING') {
     if (step === 1) return 1;
     if (step === 2) return 2;
     if (step <= 6 && step >= 1) return 3;

--- a/src/pages/seniorProfile/SeniorProfilePage.tsx
+++ b/src/pages/seniorProfile/SeniorProfilePage.tsx
@@ -15,7 +15,7 @@ import { Header } from '../../components/commons/Header';
 import ProgressBar from '../../components/commons/ProgressBar';
 import theme from '../../styles/theme';
 import { useNavigate } from 'react-router-dom';
-import { getSeniorNickname } from '@utils/storage';
+import { getSeniorId, getSeniorNickname } from '@utils/storage';
 
 const SeniorProfilePage = () => {
   const [step, setStep] = useState(0);
@@ -23,11 +23,12 @@ const SeniorProfilePage = () => {
 
   const navigate = useNavigate();
   const nickname = getSeniorNickname();
+  const seniorId = getSeniorId() ?? '';
   const userName = step >= 2 && step <= 4 ? nickname : '';
 
   useEffect(() => {
-    if (!nickname) navigate('/');
-  }, [nickname]);
+    if (seniorId === '' || !nickname) navigate('/');
+  }, [nickname, seniorId]);
 
   const getComponent = () => {
     switch (step) {
@@ -44,7 +45,7 @@ const SeniorProfilePage = () => {
       case 5:
         return <TimeSelect profile={profile} setProfile={setProfile} setStep={setStep} />;
       case 6:
-        return <PreView setStep={setStep} profile={profile} seniorId="" />;
+        return <PreView setStep={setStep} profile={profile} seniorId={seniorId} />;
       case 7:
         return <Complete />;
       default:

--- a/src/pages/seniorProfile/SeniorProfilePage.tsx
+++ b/src/pages/seniorProfile/SeniorProfilePage.tsx
@@ -14,19 +14,20 @@ import { SENIOR_PROFILE_STEPS } from './constants';
 import { Header } from '../../components/commons/Header';
 import ProgressBar from '../../components/commons/ProgressBar';
 import theme from '../../styles/theme';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
+import { getSeniorNickname } from '@utils/storage';
 
 const SeniorProfilePage = () => {
   const [step, setStep] = useState(0);
   const [profile, setProfile] = useState<seniorProfileRegisterType>(seniorProfileInitial);
-  const location = useLocation();
+
   const navigate = useNavigate();
-  const { seniorId, nickname } = location.state || {};
+  const nickname = getSeniorNickname();
   const userName = step >= 2 && step <= 4 ? nickname : '';
 
   useEffect(() => {
-    if (!seniorId || !nickname) navigate('/');
-  }, [seniorId, nickname, navigate]);
+    if (!nickname) navigate('/');
+  }, [nickname]);
 
   const getComponent = () => {
     switch (step) {
@@ -43,7 +44,7 @@ const SeniorProfilePage = () => {
       case 5:
         return <TimeSelect profile={profile} setProfile={setProfile} setStep={setStep} />;
       case 6:
-        return <PreView setStep={setStep} profile={profile} seniorId={seniorId} />;
+        return <PreView setStep={setStep} profile={profile} seniorId="" />;
       case 7:
         return <Complete />;
       default:

--- a/src/pages/seniorProfile/components/Example.tsx
+++ b/src/pages/seniorProfile/components/Example.tsx
@@ -15,9 +15,9 @@ import { useNavigate } from 'react-router-dom';
 const Example = ({ setStep }: { setStep: React.Dispatch<React.SetStateAction<number>> }) => {
   const navigate = useNavigate();
   const [seniorId, setSeniorId] = useState(0);
-  const { data: data1, isLoading: isLoading1, isError: isError1 } = useSeniorCardQuery('1');
-  const { data: data2, isLoading: isLoading2, isError: isError2 } = useSeniorCardQuery('2');
-  const { data: data3, isLoading: isLoading3, isError: isError3 } = useSeniorCardQuery('3');
+  const { data: data1, isLoading: isLoading1, isError: isError1 } = useSeniorCardQuery('1', true);
+  const { data: data2, isLoading: isLoading2, isError: isError2 } = useSeniorCardQuery('2', true);
+  const { data: data3, isLoading: isLoading3, isError: isError3 } = useSeniorCardQuery('3', true);
 
   const dummayData = [data1, data2, data3];
 

--- a/src/pages/seniorProfile/components/Init.tsx
+++ b/src/pages/seniorProfile/components/Init.tsx
@@ -44,6 +44,7 @@ const SeniorRefreshImg = styled.img`
   position: absolute;
   top: 50%;
   left: 50%;
+
   width: 25rem;
   height: 34rem;
   transform: translate(-40%, -40%);

--- a/src/pages/seniorProfile/components/preView/index.tsx
+++ b/src/pages/seniorProfile/components/preView/index.tsx
@@ -27,11 +27,7 @@ interface preViewPropType {
 
 const PreView = ({ seniorId, profile, setStep, variant = 'default' }: preViewPropType) => {
   // 선배 카드 정보 조회 (온보딩 정보)
-  const {
-    data: cardData,
-    error: cardDataError,
-    isLoading: isCardDataLoading,
-  } = useSeniorCardQuery(seniorId, variant === 'secondary');
+  const { data: cardData, error: cardDataError, isLoading: isCardDataLoading } = useSeniorCardQuery(seniorId, true);
   // 선배 상세 프로필 조회 (프로필 정보)
   const {
     data: profileData,

--- a/src/pages/seniorProfile/components/preView/index.tsx
+++ b/src/pages/seniorProfile/components/preView/index.tsx
@@ -14,6 +14,7 @@ import { dayOfWeekTimeList, seniorProfileRegisterType } from '@pages/seniorProfi
 import { deleteProfileField } from '@pages/seniorProfile/utils/deleteProfileField';
 import { weekToDay } from '@pages/seniorProfile/utils/weekToDay';
 import { useNavigate } from 'react-router-dom';
+import { setRole } from '@utils/storage';
 
 interface preViewPropType {
   seniorId: string;
@@ -25,20 +26,30 @@ interface preViewPropType {
 }
 
 const PreView = ({ seniorId, profile, setStep, variant = 'default' }: preViewPropType) => {
-  const { data: cardData, error: cardDataError, isLoading: isCardDataLoading } = useSeniorCardQuery(seniorId);
+  // 선배 카드 정보 조회 (온보딩 정보)
+  const {
+    data: cardData,
+    error: cardDataError,
+    isLoading: isCardDataLoading,
+  } = useSeniorCardQuery(seniorId, variant === 'secondary');
+  // 선배 상세 프로필 조회 (프로필 정보)
   const {
     data: profileData,
     error: profileDataError,
     isLoading: isProfileDataLoading,
-  } = useGetSeniorProfileQuery(seniorId);
+  } = useGetSeniorProfileQuery(seniorId, variant === 'secondary');
+  // 선배 선호 시간대 조회
   const {
     data: secondaryPreferredTimeList,
     isError: secondTimeListError,
     isLoading: isSecondTimeListLoading,
-  } = useSeniorTimeQuery(+seniorId);
+  } = useSeniorTimeQuery(+seniorId, variant === 'secondary');
+
   const navigate = useNavigate();
   const isRegister = variant === 'default';
 
+  // profile : 선배가 프로필 등록할 때 넘어온 값
+  // profileData : 이미 가입된 선배의 서버값 (후배가 카드 클릭시 받아오는 값)
   const career = (isRegister ? profile?.career : profileData?.career) + '';
   const award = (isRegister ? profile?.award : profileData?.award) + '';
   const catchphrase = (isRegister ? profile?.catchphrase : profileData?.catchphrase) + '';
@@ -47,6 +58,7 @@ const PreView = ({ seniorId, profile, setStep, variant = 'default' }: preViewPro
     isRegister ? profile && weekToDay(profile.isDayOfWeek, profile.preferredTimeList) : secondaryPreferredTimeList
   ) as dayOfWeekTimeList;
 
+  // 선배 프로필 등록
   const mutation = useSeniorProfileHook();
   const handleRegisterClick = () => {
     mutation.mutate(
@@ -60,6 +72,11 @@ const PreView = ({ seniorId, profile, setStep, variant = 'default' }: preViewPro
       {
         onSuccess: () => {
           setStep && setStep((prev) => prev + 1);
+          // 온보딩 + 프로필 등록 완료
+          // 선배 role SENIOR_PENDING -> SENIOR로 변경
+          // 선배 닉네임 local storage에서 제거
+          setRole('SENIOR');
+          localStorage.removeItem('seniorNickname');
         },
       }
     );
@@ -69,7 +86,7 @@ const PreView = ({ seniorId, profile, setStep, variant = 'default' }: preViewPro
     cardDataError ||
     (!isRegister && profileDataError) ||
     (!isRegister && secondTimeListError) ||
-    (!isCardDataLoading && !cardData) ||
+    (!isRegister && !isCardDataLoading && !cardData) ||
     (!isRegister && !isProfileDataLoading && !profileData) ||
     (!isRegister && !isSecondTimeListLoading && !secondaryPreferredTimeList)
   ) {

--- a/src/pages/seniorProfile/hooks/useGetSeniorProfileQuery.ts
+++ b/src/pages/seniorProfile/hooks/useGetSeniorProfileQuery.ts
@@ -1,11 +1,11 @@
-import { getSeniorProfileAxios } from "@pages/seniorProfile/apis/getSeniorProfileAxios";
-import { SeniorProfileAPIResType } from "@pages/seniorProfile/types";
-import { useQuery } from "@tanstack/react-query";
+import { getSeniorProfileAxios } from '@pages/seniorProfile/apis/getSeniorProfileAxios';
+import { SeniorProfileAPIResType } from '@pages/seniorProfile/types';
+import { useQuery } from '@tanstack/react-query';
 
-export const useGetSeniorProfileQuery = (seniorId: string) => {
+export const useGetSeniorProfileQuery = (seniorId: string, isJuniorRequest: boolean) => {
   return useQuery<SeniorProfileAPIResType, Error>({
     queryKey: ['seniorProfile', seniorId],
-    queryFn: () => getSeniorProfileAxios(seniorId).then(response => response.data.data),
-  })
+    queryFn: () => getSeniorProfileAxios(seniorId).then((response) => response.data.data),
+    enabled: !!isJuniorRequest,
+  });
 };
-

--- a/src/pages/seniorProfile/hooks/useSeniorCardQuery.ts
+++ b/src/pages/seniorProfile/hooks/useSeniorCardQuery.ts
@@ -1,10 +1,11 @@
-import { seniorCardAxios } from "@pages/seniorProfile/apis/seniorCardAxios"
-import { SeniorCardAPIResType } from "@pages/seniorProfile/types";
-import { useQuery } from "@tanstack/react-query"
+import { seniorCardAxios } from '@pages/seniorProfile/apis/seniorCardAxios';
+import { SeniorCardAPIResType } from '@pages/seniorProfile/types';
+import { useQuery } from '@tanstack/react-query';
 
-export const useSeniorCardQuery = (seniorId: string) => {
+export const useSeniorCardQuery = (seniorId: string, isJuniorRequest: boolean) => {
   return useQuery<SeniorCardAPIResType, Error>({
     queryKey: ['seniorCard', seniorId],
-    queryFn: () => seniorCardAxios(seniorId).then(response => response.data.data),
-  })
+    queryFn: () => seniorCardAxios(seniorId).then((response) => response.data.data),
+    enabled: !!isJuniorRequest,
+  });
 };

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -17,4 +17,14 @@ export const getRole = () => {
 export const clearStorage = () => {
   localStorage.removeItem('seonyakToken');
   localStorage.removeItem('seonyakRole');
+  localStorage.removeItem('seniorNickname');
+};
+
+// 온보딩 완료 후 프로필 등록 안 하고 이탈한 선배 정보 저장
+export const setSeniorNickname = (nickname: string) => {
+  localStorage.setItem('seniorNickname', nickname);
+};
+
+export const getSeniorNickname = () => {
+  return localStorage.getItem('seniorNickname');
 };

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -18,6 +18,7 @@ export const clearStorage = () => {
   localStorage.removeItem('seonyakToken');
   localStorage.removeItem('seonyakRole');
   localStorage.removeItem('seniorNickname');
+  localStorage.removeItem('seniorId');
 };
 
 // 온보딩 완료 후 프로필 등록 안 하고 이탈한 선배 정보 저장
@@ -28,3 +29,11 @@ export const setSeniorNickname = (nickname: string) => {
 export const getSeniorNickname = () => {
   return localStorage.getItem('seniorNickname');
 };
+
+export const setSeniorId = (id: string) => {
+  localStorage.setItem('seniorId', id);
+}
+
+export const getSeniorId = () => {
+  return localStorage.getItem('seniorId');
+}


### PR DESCRIPTION
<!-- # 뒤에 이슈번호를 적어주세요! -->
## #️⃣ Related Issue
Closes #350 

## ✅ Done Task
  - [x] 온보딩 완료 후 프로필 등록 하지 않은 선배 SENIOR_PENDING role 추가
  - [x] 선배 온보딩에서 프로필 등록으로 넘어갈 때 location.state로 전달하던 seniorId, nickname 로직 변경
  - [x] 선배 프로필 뷰 (Preview 컴포넌트) 로직 수정 (seniorId 조건부 전달)
  - [x] 온보딩 + 프로필 등록 완료 선배 -> SENIOR role으로 변경

## ☀️ PR Point
<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->
- 온보딩 QA를 하다가 [선배]의 경우 **온보딩 완료 후 프로필 등록을 완료하지 않고 이탈한 유저**가 재접속했을 경우, 바로 `약속 리스트 페이지`로 이동하는 문제를 발견했습니다.
- 따라서 `온보딩 후 이탈한 선배`의 경우를 핸들링 할 필요를 느껴 서버에 요청하여 `SENIOR_PENDING`이라는 role을 추가하였습니다.
- role에 대한 분기가 하나 더 늘어나서, role을 사용하는 여기저기 부분적으로 수정된 부분이 많은데, 굵직하게 변경된 부분만 PR에 작성해둘게요! 

> [선배] 온보딩 완료 / 프로필 등록 안 함 -> SENIOR_PENDING
> [선배] 온보딩 완료 / 프로필 등록 완 -> SENIOR

### 전체적인 플로우

1. `온보딩 완료 / 프로필 등록 안 한 선배`가 페이지를 이탈 한 후 선약에 재접속하면 프로필 등록 페이지로 라우팅 시켜주어야 합니다.
2. 선배 프로필 등록 플로우에는 선배가 온보딩에서 작성한 닉네임이 필요합니다. (뷰에서 사용되기 때문)
3. 기존에는 `온보딩 -> 프로필 등록 플로우`에서 사용자가 이탈하지 않고 이동한다고 가정하고 구현되었기 때문에 `온보딩 -> 프로필 등록`으로 이동할 때 `location.state`를 이용해서 닉네임을 사용했어요.
4. 하지만 이탈을 한 후 재접을 하는 경우라면 Location.state를 받아올 수 없겠죠?
5. 따라서 선배 온보딩의 마지막 단계인 문자인증 api가 성공할 경우, **outletContext에 저장된 닉네임 데이터를 localStorage에 저장하는 로직을 추가**했어요.
```typescript
// Step번호입력.tsx

  // SENIOR_PENDING - 프로필 등록 이동
  // JUNIOR - 온보딩 다음 단계로 이동
  const handleClickLink = () => {
    if (pathname.includes('senior')) {
      joinMutate.mutate(contextData, {
        onSuccess: () => {
          // ✅✅✅✅ 요 부분!!! ✅✅✅✅✅
          setSeniorNickname(contextData.nickname);
          navigate('/seniorProfile');
        },
        onError: (err) => {
          console.log(err);
        },
      });
    } else navigate('/juniorOnboarding/4');
  };
```
7. `선배 프로필 등록 페이지`에서는 로컬스토리지에 저장된 Nickname을 가져와서 사용하도록 했어요. 
8. 프로필 등록이 완료되면 localStorage에 있는 nickname이 제거되고, localStorage의 role이 SENIOR_PENDING에서 SENIOR로 변경되도록 했어요.
```typescript
// seniorProfile > index.tsx > Preview

// 선배 프로필 등록
  const mutation = useSeniorProfileHook();
  const handleRegisterClick = () => {
    mutation.mutate(
      {
        catchphrase,
        career,
        award,
        story,
        preferredTimeList: deleteProfileField(preferredTimeList),
      },
      {
        onSuccess: () => {
          setStep && setStep((prev) => prev + 1);
          // 온보딩 + 프로필 등록 완료
         // ✅✅✅✅ 여기!!!!! ✅✅✅✅
          // 선배 role SENIOR_PENDING -> SENIOR로 변경
          // 선배 닉네임 local storage에서 제거
          setRole('SENIOR');
          localStorage.removeItem('seniorNickname');
        },
      }
    );
  };
```

---
### To. 진이) Preview 컴포넌트 로직 변경
1. `Preview 컴포넌트`가 프로필 등록 직전뷰에서도 쓰이고 [후배] '둘러보기' 탭에서 선배 카드를 클릭할 경우 프로필을 불러올 때도 쓰이는 중이에요.
2. 그러다보니 `[선배] 프로필 등록 직전뷰`에서도 필요없는 api(`[후배] '둘러보기' 탭에서 선배 프로필을 보여주기` 위한 api들)을 쏘고있더라구요.
3. 그래서 `[선배] 프로필 등록 직전뷰`에 필요없는 `seniorId`를 넘기고 있길래 해당 부분 제거해주었어요.
4. 또한, `[후배] '둘러보기' 탭`에서 선배 프로필을 보여주기 위한 경우일 때만 해당 api를 쏘기 위해 관련 쿼리들에 `isJuniorRequest` 를 추가해두었어요
```typescript
// index.tsx
  // 선배 카드 정보 조회 (온보딩 정보)
  const {
    data: cardData,
    error: cardDataError,
    isLoading: isCardDataLoading,
  } = useSeniorCardQuery(seniorId, variant === 'secondary');
  // 선배 상세 프로필 조회 (프로필 정보)
  const {
    data: profileData,
    error: profileDataError,
    isLoading: isProfileDataLoading,
  } = useGetSeniorProfileQuery(seniorId, variant === 'secondary');
  // 선배 선호 시간대 조회
  const {
    data: secondaryPreferredTimeList,
    isError: secondTimeListError,
    isLoading: isSecondTimeListLoading,
  } = useSeniorTimeQuery(+seniorId, variant === 'secondary');
```

이해가 안 되시는 부분은 댓 남겨주시면 자세히 설명드릴게요 !!!!

## 💎 추가적인 부분
<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->
- 현재 해결해야하는 부분이 하나 남아있는데요

- `[선배] 온보딩 완료 / 프로필 등록 미완` 후 이탈하고 나서 나~중에 재접했을 때 **토큰이 만료된 사람**을 핸들링해야하는데요.
- 저희가 토큰이 만료된 걸 판별하는 경우는 **`authClient` 를 사용해서 api를 쐈을 때 서버에서 40076 에러를 던져주었을 때**입니다.
- 하지만, 프로필 등록이 미완된 선배가 재접했을 경우, 프로필 등록 페이지로 라우팅되게 되고, AuthClient를 사용해서 api를 쏘게되는 시점은 **선배가 열심히 프로필 등록은 완료 한 후에 '프로필 등록하기' 버튼을 눌렀을 경우에요** (혹은 다른 선배들 예시 프로필을 눌러봤을 경우)
- 따라서 . .만료된 토큰인지 확인하는 api가 필요하여 서버에 요청해두었고, 해당 부분은 다음주 월요일에 따로 이슈파서 작업하겠습니다~

## 📸 Screenshot
<!-- (선택) 구현한 부분 스크린샷 남기기 -->
- 문자인증 완료하고 회원가입시 (온보딩 완료 / 프로필 등록X) SENIOR_PENDING과 닉네임을 로컬에 저장

https://github.com/user-attachments/assets/96fa3536-71f7-4f7d-9b9f-19ce94513b4a

- 온보딩만 완료하고 이탈 후 재접시 프로필 등록 페이지로 이동

https://github.com/user-attachments/assets/aeada033-26f7-493d-a7a6-b22dea5cfbfc

- 프로필 등록 완료하면 SENIOR로 변경, Nickname 제거

https://github.com/user-attachments/assets/b6beeed6-d494-41d4-9d51-5d3f04ac07cb


